### PR TITLE
Normalize media languages and base video stats on primary streams

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # HTTP port exposed by the container
 APP_PORT=8080
 
+# Optional container/dev process timezone for logs and local-time rendering
+TZ=Europe/Berlin
+
 # Writable config directory on the host
 CONFIG_HOST_DIR=./config
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ ARG APP_VERSION=0.1.0
 
 FROM node:24-bookworm-slim AS frontend-build
 WORKDIR /app/frontend
-COPY frontend/package.json frontend/package-lock.json* ./
-RUN npm install
+COPY frontend/package.json frontend/package-lock.json ./
+RUN npm ci
 COPY frontend/ ./
 RUN npm run build
 
-FROM python:3.12-slim AS runtime
+FROM python:3.12-slim-bookworm AS runtime
 ARG APP_VERSION=0.1.0
 
 LABEL name="MediaLyze"
@@ -24,15 +24,14 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ffmpeg sqlite3 nodejs npm \
+    && apt-get install -y --no-install-recommends ffmpeg tzdata \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 COPY pyproject.toml README.md LICENSE CONTRIBUTING.md ./
 COPY backend ./backend
 COPY alembic ./alembic
-COPY frontend ./frontend
-COPY docs ./docs
-COPY tests ./tests
+COPY frontend/package.json ./frontend/package.json
 COPY --from=frontend-build /app/frontend/dist ./frontend/dist
 
 RUN pip install --no-cache-dir .

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Both scripts create `.venv` if needed, install backend/frontend dependencies whe
 - FastAPI on `http://127.0.0.1:8080`
 - Vite on `http://127.0.0.1:5173`
 
-If a project-level `.env` file exists, both scripts load variables from it first. Explicitly exported environment variables still win, and missing values fall back to the built-in defaults.
+If a project-level `.env` file exists, both scripts load variables from it first. Explicitly exported environment variables still win, and missing values fall back to the built-in defaults, including `TZ`.
 
 ## Environment
 
@@ -71,6 +71,7 @@ Relevant variables:
 - `CONFIG_PATH`: writable config/data directory, default `/config`
 - `MEDIA_ROOT`: media mount root, default `/media`
 - `APP_PORT`: HTTP port, default `8080`
+- `TZ`: optional process/container timezone like `Europe/Berlin`, default `UTC`
 - `FFPROBE_PATH`: optional override for the `ffprobe` binary path
 
 `MEDIA_ROOT` must be mounted read-only in production.

--- a/backend/app/models/entities.py
+++ b/backend/app/models/entities.py
@@ -7,14 +7,15 @@ from sqlalchemy import JSON, Boolean, DateTime, Enum as SqlEnum, Float, ForeignK
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from backend.app.db.base import Base
+from backend.app.utils.time import utc_now
 
 
 class TimestampMixin:
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime,
-        default=datetime.utcnow,
-        onupdate=datetime.utcnow,
+        DateTime(timezone=True),
+        default=utc_now,
+        onupdate=utc_now,
         nullable=False,
     )
 
@@ -53,7 +54,7 @@ class Library(TimestampMixin, Base):
     name: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
     path: Mapped[str] = mapped_column(String(2048), nullable=False, unique=True)
     type: Mapped[LibraryType] = mapped_column(SqlEnum(LibraryType, native_enum=False), nullable=False)
-    last_scan_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    last_scan_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     scan_mode: Mapped[ScanMode] = mapped_column(
         SqlEnum(ScanMode, native_enum=False),
         default=ScanMode.manual,
@@ -86,8 +87,8 @@ class MediaFile(Base):
     extension: Mapped[str] = mapped_column(String(32), nullable=False)
     size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
     mtime: Mapped[float] = mapped_column(Float, nullable=False)
-    last_seen_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
-    last_analyzed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    last_seen_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=utc_now, nullable=False)
+    last_analyzed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     scan_status: Mapped[ScanStatus] = mapped_column(
         SqlEnum(ScanStatus, native_enum=False),
         default=ScanStatus.pending,
@@ -233,8 +234,7 @@ class ScanJob(Base):
     files_total: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     files_scanned: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     errors: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
-    started_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
-    finished_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     library: Mapped[Library] = relationship(back_populates="scan_jobs")
-

--- a/backend/app/services/ffprobe_parser.py
+++ b/backend/app/services/ffprobe_parser.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from backend.app.services.languages import normalize_language_code
+
 
 def _safe_int(value: Any) -> int | None:
     if value in (None, "", "N/A"):
@@ -65,6 +67,11 @@ def _subtitle_type(codec_name: str | None) -> str | None:
     if codec_name in image_codecs:
         return "image"
     return None
+
+
+def _is_attached_picture(stream: dict[str, Any]) -> bool:
+    disposition = stream.get("disposition") or {}
+    return bool(disposition.get("attached_pic"))
 
 
 @dataclass(slots=True)
@@ -156,6 +163,8 @@ def normalize_ffprobe_payload(payload: dict[str, Any]) -> ProbeResult:
     for stream in streams:
         codec_type = stream.get("codec_type")
         if codec_type == "video":
+            if _is_attached_picture(stream):
+                continue
             normalized.video_streams.append(
                 NormalizedVideoStream(
                     stream_index=int(stream.get("index", 0)),
@@ -183,7 +192,7 @@ def normalize_ffprobe_payload(payload: dict[str, Any]) -> ProbeResult:
                     channel_layout=stream.get("channel_layout"),
                     sample_rate=_safe_int(stream.get("sample_rate")),
                     bit_rate=_safe_int(stream.get("bit_rate")),
-                    language=tags.get("language"),
+                    language=normalize_language_code(tags.get("language")),
                     default_flag=bool(disposition.get("default")),
                     forced_flag=bool(disposition.get("forced")),
                 )
@@ -196,7 +205,7 @@ def normalize_ffprobe_payload(payload: dict[str, Any]) -> ProbeResult:
                 NormalizedSubtitleStream(
                     stream_index=int(stream.get("index", 0)),
                     codec=codec_name,
-                    language=tags.get("language"),
+                    language=normalize_language_code(tags.get("language")),
                     default_flag=bool(disposition.get("default")),
                     forced_flag=bool(disposition.get("forced")),
                     subtitle_type=_subtitle_type(codec_name),
@@ -204,4 +213,3 @@ def normalize_ffprobe_payload(payload: dict[str, Any]) -> ProbeResult:
             )
 
     return normalized
-

--- a/backend/app/services/languages.py
+++ b/backend/app/services/languages.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from collections import defaultdict
+
+
+LANGUAGE_ALIASES = {
+    "und": "und",
+    "mul": "mul",
+    "zxx": "zxx",
+    "ar": "ar",
+    "ara": "ar",
+    "bg": "bg",
+    "bul": "bg",
+    "ca": "ca",
+    "cat": "ca",
+    "cs": "cs",
+    "ces": "cs",
+    "cze": "cs",
+    "da": "da",
+    "dan": "da",
+    "de": "de",
+    "deu": "de",
+    "ger": "de",
+    "el": "el",
+    "ell": "el",
+    "gre": "el",
+    "en": "en",
+    "eng": "en",
+    "es": "es",
+    "spa": "es",
+    "et": "et",
+    "est": "et",
+    "fa": "fa",
+    "fas": "fa",
+    "per": "fa",
+    "fi": "fi",
+    "fin": "fi",
+    "fr": "fr",
+    "fra": "fr",
+    "fre": "fr",
+    "he": "he",
+    "heb": "he",
+    "hi": "hi",
+    "hin": "hi",
+    "hr": "hr",
+    "hrv": "hr",
+    "hu": "hu",
+    "hun": "hu",
+    "id": "id",
+    "ind": "id",
+    "is": "is",
+    "ice": "is",
+    "isl": "is",
+    "it": "it",
+    "ita": "it",
+    "ja": "ja",
+    "jpn": "ja",
+    "ko": "ko",
+    "kor": "ko",
+    "lt": "lt",
+    "lit": "lt",
+    "lv": "lv",
+    "lav": "lv",
+    "ms": "ms",
+    "may": "ms",
+    "msa": "ms",
+    "nl": "nl",
+    "dut": "nl",
+    "nld": "nl",
+    "no": "no",
+    "nob": "no",
+    "nno": "no",
+    "nor": "no",
+    "pl": "pl",
+    "pol": "pl",
+    "pt": "pt",
+    "pob": "pt",
+    "por": "pt",
+    "ro": "ro",
+    "ron": "ro",
+    "rum": "ro",
+    "ru": "ru",
+    "rus": "ru",
+    "sk": "sk",
+    "slk": "sk",
+    "slo": "sk",
+    "sl": "sl",
+    "slv": "sl",
+    "sr": "sr",
+    "srp": "sr",
+    "sv": "sv",
+    "swe": "sv",
+    "th": "th",
+    "tha": "th",
+    "tr": "tr",
+    "tur": "tr",
+    "uk": "uk",
+    "ukr": "uk",
+    "vi": "vi",
+    "vie": "vi",
+    "zh": "zh",
+    "chi": "zh",
+    "zho": "zh",
+}
+
+
+def _known_language_alias(value: str) -> str | None:
+    candidate = value.strip().lower()
+    if not candidate:
+        return None
+
+    direct = LANGUAGE_ALIASES.get(candidate)
+    if direct:
+        return direct
+
+    for separator in ("-", "_"):
+        if separator in candidate:
+            base = candidate.split(separator, 1)[0]
+            mapped = LANGUAGE_ALIASES.get(base)
+            if mapped:
+                return mapped
+
+    return None
+
+
+def normalize_language_code(value: str | None) -> str | None:
+    if value is None:
+        return None
+
+    candidate = value.strip().lower()
+    if not candidate:
+        return None
+
+    return _known_language_alias(candidate) or candidate
+
+
+def normalize_language_hint(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return _known_language_alias(value)
+
+
+def merge_language_counts(
+    rows: list[tuple[str | None, int]] | tuple[tuple[str | None, int], ...],
+    *,
+    fallback: str = "und",
+) -> list[tuple[str, int]]:
+    counts: dict[str, int] = defaultdict(int)
+    for label, value in rows:
+        key = normalize_language_code(label) or fallback
+        counts[key] += value
+    return sorted(counts.items(), key=lambda item: (-item[1], item[0]))

--- a/backend/app/services/library_service.py
+++ b/backend/app/services/library_service.py
@@ -9,7 +9,9 @@ from sqlalchemy.orm import Session
 from backend.app.core.config import Settings
 from backend.app.models.entities import AudioStream, Library, MediaFile, MediaFormat, ScanStatus, SubtitleStream, VideoStream
 from backend.app.schemas.library import LibraryCreate, LibraryDetail, LibrarySummary, LibraryUpdate
+from backend.app.services.languages import merge_language_counts
 from backend.app.utils.pathing import ensure_relative_to_root
+from backend.app.services.video_queries import primary_video_streams_subquery
 
 
 DEFAULT_SCAN_CONFIG = {
@@ -120,26 +122,35 @@ def get_library_detail(db: Session, library_id: int) -> LibraryDetail | None:
     for key, value in _library_aggregate_map(db).get(library.id, {}).items():
         setattr(summary, key, value)
 
+    primary_video_streams = primary_video_streams_subquery("library_primary_video_streams")
+
     video_codec_distribution = db.execute(
-        select(VideoStream.codec, func.count(VideoStream.id))
-        .join(MediaFile, MediaFile.id == VideoStream.media_file_id)
+        select(primary_video_streams.c.codec, func.count(primary_video_streams.c.id))
+        .join(MediaFile, MediaFile.id == primary_video_streams.c.media_file_id)
         .where(MediaFile.library_id == library_id)
-        .group_by(VideoStream.codec)
-        .order_by(func.count(VideoStream.id).desc())
+        .group_by(primary_video_streams.c.codec)
+        .order_by(func.count(primary_video_streams.c.id).desc())
     ).all()
     resolution_distribution = db.execute(
-        select(VideoStream.width, VideoStream.height, func.count(VideoStream.id))
-        .join(MediaFile, MediaFile.id == VideoStream.media_file_id)
+        select(
+            primary_video_streams.c.width,
+            primary_video_streams.c.height,
+            func.count(primary_video_streams.c.id),
+        )
+        .join(MediaFile, MediaFile.id == primary_video_streams.c.media_file_id)
         .where(MediaFile.library_id == library_id)
-        .group_by(VideoStream.width, VideoStream.height)
-        .order_by(func.count(VideoStream.id).desc())
+        .group_by(primary_video_streams.c.width, primary_video_streams.c.height)
+        .order_by(func.count(primary_video_streams.c.id).desc())
     ).all()
     hdr_distribution = db.execute(
-        select(func.coalesce(VideoStream.hdr_type, "SDR"), func.count(VideoStream.id))
-        .join(MediaFile, MediaFile.id == VideoStream.media_file_id)
+        select(
+            func.coalesce(primary_video_streams.c.hdr_type, "SDR"),
+            func.count(primary_video_streams.c.id),
+        )
+        .join(MediaFile, MediaFile.id == primary_video_streams.c.media_file_id)
         .where(MediaFile.library_id == library_id)
-        .group_by(func.coalesce(VideoStream.hdr_type, "SDR"))
-        .order_by(func.count(VideoStream.id).desc())
+        .group_by(func.coalesce(primary_video_streams.c.hdr_type, "SDR"))
+        .order_by(func.count(primary_video_streams.c.id).desc())
     ).all()
     audio_language_distribution = db.execute(
         select(AudioStream.language, func.count(AudioStream.id))
@@ -149,13 +160,16 @@ def get_library_detail(db: Session, library_id: int) -> LibraryDetail | None:
         .order_by(func.count(AudioStream.id).desc())
     ).all()
     subtitle_counts: dict[str, int] = defaultdict(int)
-    for language, count in db.execute(
-        select(SubtitleStream.language, func.count(SubtitleStream.id))
-        .join(MediaFile, MediaFile.id == SubtitleStream.media_file_id)
-        .where(MediaFile.library_id == library_id)
-        .group_by(SubtitleStream.language)
+    for language, count in merge_language_counts(
+        db.execute(
+            select(SubtitleStream.language, func.count(SubtitleStream.id))
+            .join(MediaFile, MediaFile.id == SubtitleStream.media_file_id)
+            .where(MediaFile.library_id == library_id)
+            .group_by(SubtitleStream.language)
+        ).all(),
+        fallback="und",
     ):
-        subtitle_counts[language or "und"] += count
+        subtitle_counts[language] += count
 
     return LibraryDetail(
         **summary.model_dump(),
@@ -166,8 +180,8 @@ def get_library_detail(db: Session, library_id: int) -> LibraryDetail | None:
         ],
         hdr_distribution=[{"label": key or "SDR", "value": value} for key, value in hdr_distribution],
         audio_language_distribution=[
-            {"label": key or "und", "value": value}
-            for key, value in audio_language_distribution
+            {"label": key, "value": value}
+            for key, value in merge_language_counts(audio_language_distribution, fallback="und")
         ],
         subtitle_language_distribution=[
             {"label": key, "value": value}

--- a/backend/app/services/media_service.py
+++ b/backend/app/services/media_service.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session, selectinload
 
 from backend.app.models.entities import MediaFile
 from backend.app.schemas.media import MediaFileDetail, MediaFileTableRow
+from backend.app.services.languages import normalize_language_code
 
 
 def _row_from_model(media_file: MediaFile) -> MediaFileTableRow:
@@ -30,10 +31,10 @@ def _row_from_model(media_file: MediaFile) -> MediaFileTableRow:
         video_codec=primary_video.codec if primary_video else None,
         resolution=resolution,
         hdr_type=primary_video.hdr_type if primary_video else None,
-        audio_languages=sorted({stream.language or "und" for stream in media_file.audio_streams}),
+        audio_languages=sorted({normalize_language_code(stream.language) or "und" for stream in media_file.audio_streams}),
         subtitle_languages=sorted(
-            {stream.language or "und" for stream in media_file.subtitle_streams}
-            | {subtitle.language or "und" for subtitle in media_file.external_subtitles}
+            {normalize_language_code(stream.language) or "und" for stream in media_file.subtitle_streams}
+            | {normalize_language_code(subtitle.language) or "und" for subtitle in media_file.external_subtitles}
         ),
     )
 
@@ -79,4 +80,3 @@ def get_media_file_detail(db: Session, file_id: int) -> MediaFileDetail | None:
         external_subtitles=media_file.external_subtitles,
         raw_ffprobe_json=media_file.raw_ffprobe_json,
     )
-

--- a/backend/app/services/runtime.py
+++ b/backend/app/services/runtime.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
 from pathlib import Path
 from threading import Lock, Timer
 
@@ -13,6 +12,7 @@ from watchdog.observers import Observer
 from backend.app.core.config import Settings
 from backend.app.db.session import SessionLocal
 from backend.app.models.entities import JobStatus, Library, ScanJob, ScanMode
+from backend.app.utils.time import utc_now
 from backend.app.services.scanner import execute_scan_job, queue_scan_job
 
 
@@ -217,7 +217,7 @@ class ScanRuntimeManager:
             for job in active_jobs:
                 if job.library_id in seen_libraries:
                     job.status = JobStatus.failed
-                    job.finished_at = datetime.utcnow()
+                    job.finished_at = utc_now()
                     job.errors += 1
                     continue
                 seen_libraries.add(job.library_id)

--- a/backend/app/services/scanner.py
+++ b/backend/app/services/scanner.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
 from pathlib import Path
 import traceback
 
@@ -25,6 +24,7 @@ from backend.app.models.entities import (
 from backend.app.services.ffprobe_parser import normalize_ffprobe_payload, run_ffprobe
 from backend.app.services.quality import calculate_quality_score
 from backend.app.services.subtitles import detect_external_subtitles
+from backend.app.utils.time import utc_now
 
 
 def _library_root(library: Library) -> Path:
@@ -132,7 +132,7 @@ def execute_scan_job(job_id: int, settings: Settings) -> None:
         job = db.get(ScanJob, job_id)
         if job:
             job.status = JobStatus.failed
-            job.finished_at = datetime.utcnow()
+            job.finished_at = utc_now()
             job.errors += 1
             db.commit()
     finally:
@@ -144,7 +144,7 @@ def _run_scan_job(db: Session, settings: Settings, job_id: int) -> ScanJob:
     if not job:
         raise ValueError(f"Scan job {job_id} not found")
     job.status = JobStatus.running
-    job.started_at = datetime.utcnow()
+    job.started_at = utc_now()
     db.commit()
     db.refresh(job)
     return run_scan(db, settings, job.library_id, job.job_type, job)
@@ -166,7 +166,7 @@ def run_scan(
         library_id=library_id,
         status=JobStatus.running,
         job_type=scan_type,
-        started_at=datetime.utcnow(),
+        started_at=utc_now(),
     )
     if existing_job is None:
         db.add(job)
@@ -196,7 +196,7 @@ def run_scan(
                 extension=file_path.suffix.lower().lstrip("."),
                 size_bytes=stat.st_size,
                 mtime=stat.st_mtime,
-                last_seen_at=datetime.utcnow(),
+                last_seen_at=utc_now(),
                 scan_status=ScanStatus.pending,
             )
             db.add(media_file)
@@ -208,7 +208,7 @@ def run_scan(
             media_file.extension = file_path.suffix.lower().lstrip(".")
             media_file.size_bytes = stat.st_size
             media_file.mtime = stat.st_mtime
-            media_file.last_seen_at = datetime.utcnow()
+            media_file.last_seen_at = utc_now()
             if changed or scan_type == "full":
                 media_file.scan_status = ScanStatus.pending
                 to_analyze.append((media_file, file_path))
@@ -241,7 +241,7 @@ def run_scan(
                 media_file.raw_ffprobe_json = payload
                 _replace_analysis(media_file, normalized, subtitles)
                 media_file.quality_score = calculate_quality_score(normalized)
-                media_file.last_analyzed_at = datetime.utcnow()
+                media_file.last_analyzed_at = utc_now()
                 media_file.scan_status = ScanStatus.ready
             else:
                 media_file.scan_status = ScanStatus.failed
@@ -255,9 +255,9 @@ def run_scan(
         if batch_counter:
             db.commit()
 
-    library.last_scan_at = datetime.utcnow()
+    library.last_scan_at = utc_now()
     job.status = JobStatus.failed if job.errors else JobStatus.completed
-    job.finished_at = datetime.utcnow()
+    job.finished_at = utc_now()
     db.commit()
     db.refresh(job)
     return job

--- a/backend/app/services/stats.py
+++ b/backend/app/services/stats.py
@@ -13,6 +13,8 @@ from backend.app.models.entities import (
     VideoStream,
 )
 from backend.app.schemas.media import DashboardResponse, DistributionItem
+from backend.app.services.languages import merge_language_counts
+from backend.app.services.video_queries import primary_video_streams_subquery
 
 
 def _distribution(rows: list[tuple[str | None, int]], fallback: str = "unknown") -> list[DistributionItem]:
@@ -30,6 +32,7 @@ def _resolution_label(width: int | None, height: int | None) -> str:
 
 
 def build_dashboard(db: Session) -> DashboardResponse:
+    primary_video_streams = primary_video_streams_subquery()
     totals = {
         "libraries": db.scalar(select(func.count(Library.id))) or 0,
         "files": db.scalar(select(func.count(MediaFile.id))) or 0,
@@ -38,19 +41,26 @@ def build_dashboard(db: Session) -> DashboardResponse:
     }
 
     video_codec_rows = db.execute(
-        select(VideoStream.codec, func.count(VideoStream.id))
-        .group_by(VideoStream.codec)
-        .order_by(func.count(VideoStream.id).desc())
+        select(primary_video_streams.c.codec, func.count(primary_video_streams.c.id))
+        .group_by(primary_video_streams.c.codec)
+        .order_by(func.count(primary_video_streams.c.id).desc())
     ).all()
     resolution_rows = db.execute(
-        select(VideoStream.width, VideoStream.height, func.count(VideoStream.id))
-        .group_by(VideoStream.width, VideoStream.height)
-        .order_by(func.count(VideoStream.id).desc())
+        select(
+            primary_video_streams.c.width,
+            primary_video_streams.c.height,
+            func.count(primary_video_streams.c.id),
+        )
+        .group_by(primary_video_streams.c.width, primary_video_streams.c.height)
+        .order_by(func.count(primary_video_streams.c.id).desc())
     ).all()
     hdr_rows = db.execute(
-        select(func.coalesce(VideoStream.hdr_type, "SDR"), func.count(VideoStream.id))
-        .group_by(func.coalesce(VideoStream.hdr_type, "SDR"))
-        .order_by(func.count(VideoStream.id).desc())
+        select(
+            func.coalesce(primary_video_streams.c.hdr_type, "SDR"),
+            func.count(primary_video_streams.c.id),
+        )
+        .group_by(func.coalesce(primary_video_streams.c.hdr_type, "SDR"))
+        .order_by(func.count(primary_video_streams.c.id).desc())
     ).all()
     audio_codec_rows = db.execute(
         select(AudioStream.codec, func.count(AudioStream.id))
@@ -75,10 +85,12 @@ def build_dashboard(db: Session) -> DashboardResponse:
         ],
         hdr_distribution=_distribution(hdr_rows, fallback="SDR"),
         audio_codec_distribution=_distribution(audio_codec_rows),
-        audio_language_distribution=_distribution(audio_language_rows, fallback="und"),
+        audio_language_distribution=[
+            DistributionItem(label=label, value=value)
+            for label, value in merge_language_counts(audio_language_rows, fallback="und")
+        ],
         subtitle_distribution=[
             DistributionItem(label="internal", value=internal_subtitles),
             DistributionItem(label="external", value=external_subtitles),
         ],
     )
-

--- a/backend/app/services/subtitles.py
+++ b/backend/app/services/subtitles.py
@@ -1,22 +1,6 @@
 from pathlib import Path
 
-
-LANGUAGE_HINTS = {
-    "de",
-    "deu",
-    "ger",
-    "en",
-    "eng",
-    "fr",
-    "fre",
-    "spa",
-    "es",
-    "it",
-    "ita",
-    "jpn",
-    "ja",
-    "und",
-}
+from backend.app.services.languages import normalize_language_hint
 
 
 def detect_external_subtitles(video_path: Path, allowed_extensions: tuple[str, ...]) -> list[dict[str, str | None]]:
@@ -38,7 +22,11 @@ def detect_external_subtitles(video_path: Path, allowed_extensions: tuple[str, .
 
         middle = entry.name[len(stem) : -len(entry.suffix)]
         tokens = [token.lower() for token in middle.split(".") if token]
-        language = next((token for token in tokens if token in LANGUAGE_HINTS), None)
+        language = None
+        for token in tokens:
+            language = normalize_language_hint(token)
+            if language:
+                break
 
         detected.append(
             {
@@ -49,4 +37,3 @@ def detect_external_subtitles(video_path: Path, allowed_extensions: tuple[str, .
         )
 
     return detected
-

--- a/backend/app/services/video_queries.py
+++ b/backend/app/services/video_queries.py
@@ -1,0 +1,25 @@
+from sqlalchemy import Select, func, select
+
+from backend.app.models.entities import VideoStream
+
+
+def primary_video_streams_subquery(name: str = "primary_video_streams"):
+    primary_indices = (
+        select(
+            VideoStream.media_file_id.label("media_file_id"),
+            func.min(VideoStream.stream_index).label("stream_index"),
+        )
+        .group_by(VideoStream.media_file_id)
+        .subquery(f"{name}_indices")
+    )
+
+    return (
+        select(VideoStream)
+        .join(
+            primary_indices,
+            (VideoStream.media_file_id == primary_indices.c.media_file_id)
+            & (VideoStream.stream_index == primary_indices.c.stream_index),
+        )
+        .subquery(name)
+    )
+

--- a/backend/app/utils/time.py
+++ b/backend/app/utils/time.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+
+def utc_now() -> datetime:
+    return datetime.now(UTC)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
       APP_PORT: ${APP_PORT:-8080}
       CONFIG_PATH: /config
       MEDIA_ROOT: /media
+      TZ: ${TZ:-UTC}
     volumes:
       - ${CONFIG_HOST_DIR:-./config}:/config
       - ${MEDIA_HOST_DIR:-./media}:/media:ro

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "i18next": "^25.0.1",
+        "lucide-react": "^0.577.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-i18next": "^15.5.0",
@@ -1241,6 +1242,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/nanoid": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "i18next": "^25.0.1",
+    "lucide-react": "^0.577.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-i18next": "^15.5.0",

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,11 +1,41 @@
-import { NavLink, Outlet } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { NavLink, Outlet, useLocation } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { House, Settings } from "lucide-react";
 
+import { api, type LibrarySummary } from "../lib/api";
 import { useScanJobs } from "../lib/scan-jobs";
 
 export function AppShell() {
   const { t } = useTranslation();
+  const location = useLocation();
   const { activeJobs } = useScanJobs();
+  const [libraries, setLibraries] = useState<LibrarySummary[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadLibraries() {
+      try {
+        const items = await api.libraries();
+        if (!cancelled) {
+          setLibraries(items);
+        }
+      } catch {
+        // Keep the last known library navigation state on transient errors.
+      }
+    }
+
+    void loadLibraries();
+    const timer = window.setInterval(() => {
+      void loadLibraries();
+    }, 5000);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [location.pathname]);
 
   return (
     <div className="layout media-app-shell">
@@ -15,30 +45,42 @@ export function AppShell() {
           <div>
             <h1>{t("app.title")}</h1>
           </div>
-          <nav className="tabs has-pill media-nav" aria-label="Primary">
-            <NavLink
-              to="/"
-              end
-              className={({ isActive }) => `tab-button ${isActive ? "active" : ""}`.trim()}
-            >
-              {t("nav.dashboard")}
-            </NavLink>
-            <NavLink
-              to="/libraries"
-              className={({ isActive }) => `tab-button ${isActive ? "active" : ""}`.trim()}
-            >
-              {t("nav.libraries")}
-            </NavLink>
+          <nav className="media-nav-panel" aria-label="Primary">
+            <div className="media-nav-icons">
+              <NavLink
+                to="/"
+                end
+                aria-label="Home"
+                className={({ isActive }) => `icon-nav-button ${isActive ? "active" : ""}`.trim()}
+              >
+                <House aria-hidden="true" className="nav-icon" />
+              </NavLink>
+              <NavLink
+                to="/libraries"
+                end
+                aria-label="Settings"
+                className={({ isActive }) => `icon-nav-button ${isActive ? "active" : ""}`.trim()}
+              >
+                <Settings aria-hidden="true" className="nav-icon" />
+              </NavLink>
+            </div>
+            <div className="media-nav-libraries">
+              {libraries.map((library) => (
+                <NavLink
+                  key={library.id}
+                  to={`/libraries/${library.id}`}
+                  className={({ isActive }) => `library-nav-link ${isActive ? "active" : ""}`.trim()}
+                >
+                  {library.name}
+                </NavLink>
+              ))}
+            </div>
           </nav>
         </div>
         {activeJobs.length > 0 ? (
           <div className="scan-banner">
             <div className="scan-banner-copy">
               <strong>Scan running in background</strong>
-              <span>
-                {activeJobs.length} active job{activeJobs.length > 1 ? "s" : ""}. Reloading or
-                navigating away in the UI does not stop them.
-              </span>
             </div>
             <div className="scan-banner-list">
               {activeJobs.map((job) => (

--- a/frontend/src/components/AsyncPanel.tsx
+++ b/frontend/src/components/AsyncPanel.tsx
@@ -6,6 +6,7 @@ type AsyncPanelProps = {
   loading?: boolean;
   error?: string | null;
   bodyClassName?: string;
+  headerAddon?: ReactNode;
   children: ReactNode;
 };
 
@@ -15,13 +16,17 @@ export function AsyncPanel({
   loading,
   error,
   bodyClassName,
+  headerAddon,
   children,
 }: AsyncPanelProps) {
   return (
     <section className="panel async-panel">
       <div className="panel-header">
         <div>
-          <h2>{title}</h2>
+          <div className="panel-title-row">
+            <h2>{title}</h2>
+            {headerAddon}
+          </div>
           {subtitle ? <p className="subtitle">{subtitle}</p> : null}
         </div>
       </div>

--- a/frontend/src/medialyze.css
+++ b/frontend/src/medialyze.css
@@ -11,10 +11,69 @@
 
 .media-header {
   gap: 16px;
+  align-items: start;
 }
 
-.media-nav {
+.media-nav-panel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: flex-end;
   margin-left: auto;
+}
+
+.media-nav-icons,
+.media-nav-libraries {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(31, 28, 22, 0.08);
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.media-nav-libraries {
+  flex-wrap: wrap;
+  max-width: min(100%, 860px);
+}
+
+.icon-nav-button,
+.library-nav-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 40px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  color: var(--muted);
+  transition: background 0.16s ease, color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.icon-nav-button:hover,
+.library-nav-link:hover {
+  background: rgba(255, 255, 255, 0.84);
+  color: var(--ink);
+  box-shadow: 0 8px 16px rgba(31, 28, 22, 0.08);
+}
+
+.icon-nav-button.active,
+.library-nav-link.active {
+  background: rgba(255, 255, 255, 0.96);
+  color: var(--ink);
+  box-shadow: 0 8px 16px rgba(31, 28, 22, 0.08);
+}
+
+.library-nav-link {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.nav-icon {
+  width: 18px;
+  height: 18px;
 }
 
 .scan-banner {
@@ -63,6 +122,12 @@
 .async-panel .panel-header {
   align-self: start;
   margin-bottom: 12px;
+}
+
+.panel-title-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .async-panel-body {
@@ -159,6 +224,28 @@
   font-size: 0.88rem;
 }
 
+.library-settings-card {
+  gap: 14px;
+}
+
+.library-settings-header {
+  display: grid;
+  gap: 10px;
+}
+
+.library-settings-form {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: end;
+}
+
+.library-settings-actions {
+  display: grid;
+  gap: 10px;
+  align-content: end;
+}
+
 .scan-badge {
   background: rgba(27, 153, 139, 0.16);
   color: #0e6b62;
@@ -192,51 +279,224 @@
   border-color: rgba(255, 107, 61, 0.24);
 }
 
+.scan-settings-form {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: start;
+}
+
+.scan-settings-actions {
+  display: grid;
+  gap: 10px;
+  align-content: start;
+}
+
+.tooltip-trigger {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  background: rgba(31, 28, 22, 0.08);
+  color: var(--muted);
+  font-size: 0.8rem;
+  font-weight: 700;
+  cursor: help;
+}
+
+.tooltip-trigger::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 10px);
+  transform: translateX(-50%);
+  width: min(320px, 70vw);
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(31, 28, 22, 0.94);
+  color: #f3efe8;
+  font-size: 0.82rem;
+  line-height: 1.35;
+  box-shadow: 0 14px 28px rgba(31, 28, 22, 0.18);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.16s ease, transform 0.16s ease;
+}
+
+.tooltip-trigger:hover::after,
+.tooltip-trigger:focus-visible::after {
+  opacity: 1;
+  transform: translateX(-50%) translateY(-2px);
+}
+
 .compact-row-card {
   grid-template-columns: auto 1fr auto;
   gap: 12px;
   align-items: center;
 }
 
-.media-table {
+.data-table-tools {
   display: grid;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.data-table-state,
+.column-picker {
+  display: flex;
+  flex-wrap: wrap;
   gap: 8px;
 }
 
-.media-table-head,
-.media-table-row {
-  display: grid;
-  grid-template-columns: minmax(0, 2.6fr) repeat(4, minmax(0, 1fr));
-  gap: 12px;
-  align-items: center;
-}
-
-.media-table-head {
-  padding: 0 12px;
+.column-toggle {
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(31, 28, 22, 0.12);
+  background: rgba(255, 255, 255, 0.72);
   color: var(--muted);
   font-size: 0.82rem;
+}
+
+.column-toggle.is-active {
+  border-color: rgba(27, 153, 139, 0.24);
+  background: rgba(27, 153, 139, 0.12);
+  color: #0e6b62;
+}
+
+.column-toggle:disabled {
+  opacity: 0.72;
+  cursor: default;
+}
+
+.data-table-shell {
+  overflow-x: auto;
+  border-radius: 18px;
+  border: 1px solid rgba(31, 28, 22, 0.08);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.media-data-table {
+  width: 100%;
+  min-width: 920px;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.media-data-table th,
+.media-data-table td {
+  min-width: 0;
+  padding: 12px 14px;
+  text-align: left;
+  vertical-align: top;
+  border-bottom: 1px solid rgba(31, 28, 22, 0.08);
+}
+
+.media-data-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: rgba(243, 239, 232, 0.96);
+}
+
+.media-data-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.media-data-table tbody tr:hover td {
+  background: rgba(255, 255, 255, 0.54);
+}
+
+.media-data-table .is-sticky {
+  position: sticky;
+  left: 0;
+  z-index: 1;
+  background: inherit;
+}
+
+.media-data-table thead .is-sticky {
+  z-index: 3;
+  background: rgba(243, 239, 232, 0.98);
+}
+
+.column-sort {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font-size: 0.78rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
 }
 
-.media-table-row {
-  padding: 14px 12px;
-  border-radius: 16px;
-  background: rgba(255, 255, 255, 0.72);
-  border: 1px solid rgba(31, 28, 22, 0.08);
+.sort-indicator {
+  font-size: 0.7rem;
+  color: rgba(31, 28, 22, 0.38);
 }
 
-.media-table-row span,
-.media-table-head span {
-  min-width: 0;
+.sort-indicator.is-active {
+  color: #0e6b62;
 }
 
-.media-table-row small {
-  display: block;
+.media-file-cell {
+  display: grid;
+  gap: 4px;
+}
+
+.file-link {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.file-link:hover {
+  color: #0e6b62;
+}
+
+.media-file-cell small {
   color: var(--muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.score-cell {
+  display: grid;
+  gap: 8px;
+  min-width: 120px;
+}
+
+.score-meter {
+  overflow: hidden;
+  height: 9px;
+  border-radius: 999px;
+  background: rgba(31, 28, 22, 0.08);
+}
+
+.score-meter-fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #cf5345 0%, #d8a442 52%, #27946b 100%);
+}
+
+.score-meter-fill-low {
+  background: linear-gradient(90deg, #cf5345 0%, #d97358 100%);
+}
+
+.score-meter-fill-medium {
+  background: linear-gradient(90deg, #d07a4a 0%, #d8b24f 100%);
+}
+
+.score-meter-fill-high {
+  background: linear-gradient(90deg, #89af4b 0%, #27946b 100%);
 }
 
 .json-preview {
@@ -259,11 +519,12 @@
     position: static;
   }
 
-  .media-table-head {
-    display: none;
+  .media-nav-panel {
+    width: 100%;
+    justify-content: flex-start;
   }
 
-  .media-table-row {
-    grid-template-columns: 1fr 1fr;
+  .media-nav-libraries {
+    width: 100%;
   }
 }

--- a/frontend/src/pages/LibrariesPage.tsx
+++ b/frontend/src/pages/LibrariesPage.tsx
@@ -21,14 +21,29 @@ export function LibrariesPage() {
   const [error, setError] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [settingsForms, setSettingsForms] = useState<
+    Record<number, { scan_mode: string; interval_minutes: number; debounce_seconds: number }>
+  >({});
+  const [libraryMessages, setLibraryMessages] = useState<Record<number, string | null>>({});
   const [form, setForm] = useState(EMPTY_FORM);
-  const { activeJobs, hasActiveJobs } = useScanJobs();
+  const { activeJobs, hasActiveJobs, refresh } = useScanJobs();
 
   const loadLibraries = () => {
     api
       .libraries()
       .then((payload) => {
         setLibraries(payload);
+        setSettingsForms((current) => {
+          const next = { ...current };
+          for (const library of payload) {
+            next[library.id] ??= {
+              scan_mode: library.scan_mode,
+              interval_minutes: Number(library.scan_config.interval_minutes ?? 60),
+              debounce_seconds: Number(library.scan_config.debounce_seconds ?? 15),
+            };
+          }
+          return next;
+        });
         setError(null);
       })
       .catch((reason: Error) => setError(reason.message));
@@ -61,58 +76,61 @@ export function LibrariesPage() {
     }
   }
 
+  function updateLibraryForm(
+    libraryId: number,
+    patch: Partial<{ scan_mode: string; interval_minutes: number; debounce_seconds: number }>,
+  ) {
+    setSettingsForms((current) => ({
+      ...current,
+      [libraryId]: {
+        scan_mode: current[libraryId]?.scan_mode ?? "manual",
+        interval_minutes: current[libraryId]?.interval_minutes ?? 60,
+        debounce_seconds: current[libraryId]?.debounce_seconds ?? 15,
+        ...patch,
+      },
+    }));
+  }
+
+  async function saveLibrarySettings(libraryId: number) {
+    const current = settingsForms[libraryId];
+    if (!current) {
+      return;
+    }
+    try {
+      await api.updateLibrarySettings(libraryId, {
+        scan_mode: current.scan_mode,
+        scan_config:
+          current.scan_mode === "scheduled"
+            ? { interval_minutes: current.interval_minutes }
+            : current.scan_mode === "watch"
+              ? { debounce_seconds: current.debounce_seconds }
+              : {},
+      });
+      setLibraryMessages((messages) => ({ ...messages, [libraryId]: "Settings saved." }));
+      loadLibraries();
+    } catch (reason) {
+      setLibraryMessages((messages) => ({ ...messages, [libraryId]: (reason as Error).message }));
+    }
+  }
+
+  async function runLibraryScan(libraryId: number, scanType: "incremental" | "full" = "incremental") {
+    try {
+      await api.scanLibrary(libraryId, scanType);
+      setLibraryMessages((messages) => ({ ...messages, [libraryId]: null }));
+      await refresh();
+      loadLibraries();
+    } catch (reason) {
+      setLibraryMessages((messages) => ({ ...messages, [libraryId]: (reason as Error).message }));
+    }
+  }
+
   return (
     <>
-      <section className="panel stack">
-        <p className="eyebrow">{t("libraries.eyebrow")}</p>
-        <h2>{t("libraries.title")}</h2>
-        <p className="subtitle">{t("libraries.subtitle")}</p>
-      </section>
-
-      <div className="media-grid">
-        <AsyncPanel
-          title="Create library"
-          subtitle="Path selection is restricted to directories below MEDIA_ROOT."
-          error={submitError}
-        >
-          <form className="form-grid" onSubmit={handleSubmit}>
-            <div className="field">
-              <label htmlFor="library-name">Name</label>
-              <input
-                id="library-name"
-                value={form.name}
-                onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
-                placeholder="Movies archive"
-                required
-              />
-            </div>
-            <div className="field">
-              <label htmlFor="library-type">Library type</label>
-              <select
-                id="library-type"
-                value={form.type}
-                onChange={(event) => setForm((current) => ({ ...current, type: event.target.value }))}
-              >
-                <option value="movies">movies</option>
-                <option value="series">series</option>
-                <option value="mixed">mixed</option>
-                <option value="other">other</option>
-              </select>
-            </div>
-            <PathBrowser
-              value={form.path}
-              onChange={(path) => setForm((current) => ({ ...current, path }))}
-            />
-            <button type="submit" disabled={submitting}>
-              {submitting ? "Creating…" : "Create library"}
-            </button>
-          </form>
-        </AsyncPanel>
-
-        <AsyncPanel title="Configured libraries" loading={!libraries.length && !error} error={error}>
-          <div className="listing">
-            {libraries.map((library) => (
-              <Link className="media-card library-card" key={library.id} to={`/libraries/${library.id}`}>
+      <AsyncPanel title="Configured libraries" loading={!libraries.length && !error} error={error}>
+        <div className="listing">
+          {libraries.map((library) => (
+            <div className="media-card library-settings-card" key={library.id}>
+              <div className="library-settings-header">
                 <div className="item-meta">
                   <div className="meta-tags">
                     <span className="badge">{library.type}</span>
@@ -121,11 +139,15 @@ export function LibrariesPage() {
                       .filter((job) => job.library_id === library.id)
                       .map((job) => (
                         <span className="badge scan-badge" key={job.id}>
-                          {job.phase_label} {job.files_total > 0 ? `${job.progress_percent}%` : ""}
+                          {job.files_total > 0 ? `${job.progress_percent}%` : "active"}
                         </span>
                       ))}
                   </div>
-                  <h3>{library.name}</h3>
+                  <h3>
+                    <Link to={`/libraries/${library.id}`} className="file-link">
+                      {library.name}
+                    </Link>
+                  </h3>
                   <p className="media-meta">{library.path}</p>
                 </div>
                 <div className="library-stats">
@@ -134,20 +156,135 @@ export function LibrariesPage() {
                   <span>{formatDuration(library.total_duration_seconds)}</span>
                   <span>Last scan: {formatDate(library.last_scan_at)}</span>
                 </div>
-                {activeJobs.find((job) => job.library_id === library.id) ? (
-                  <div className="progress">
-                    <span
-                      style={{
-                        width: `${activeJobs.find((job) => job.library_id === library.id)?.progress_percent ?? 0}%`,
-                      }}
+              </div>
+              {activeJobs.find((job) => job.library_id === library.id) ? (
+                <div className="progress">
+                  <span
+                    style={{
+                      width: `${activeJobs.find((job) => job.library_id === library.id)?.progress_percent ?? 0}%`,
+                    }}
+                  />
+                </div>
+              ) : null}
+              <form
+                className="library-settings-form"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  void saveLibrarySettings(library.id);
+                }}
+              >
+                <div className="field">
+                  <label htmlFor={`scan-mode-${library.id}`}>Mode</label>
+                  <select
+                    id={`scan-mode-${library.id}`}
+                    value={settingsForms[library.id]?.scan_mode ?? library.scan_mode}
+                    onChange={(event) =>
+                      updateLibraryForm(library.id, { scan_mode: event.target.value })
+                    }
+                  >
+                    <option value="manual">manual</option>
+                    <option value="scheduled">scheduled</option>
+                    <option value="watch">watch</option>
+                  </select>
+                </div>
+                {(settingsForms[library.id]?.scan_mode ?? library.scan_mode) === "scheduled" ? (
+                  <div className="field">
+                    <label htmlFor={`interval-minutes-${library.id}`}>Interval in minutes</label>
+                    <input
+                      id={`interval-minutes-${library.id}`}
+                      type="number"
+                      min={5}
+                      value={settingsForms[library.id]?.interval_minutes ?? 60}
+                      onChange={(event) =>
+                        updateLibraryForm(library.id, {
+                          interval_minutes: Number(event.target.value),
+                        })
+                      }
                     />
                   </div>
                 ) : null}
-              </Link>
-            ))}
+                {(settingsForms[library.id]?.scan_mode ?? library.scan_mode) === "watch" ? (
+                  <div className="field">
+                    <label htmlFor={`debounce-seconds-${library.id}`}>Debounce in seconds</label>
+                    <input
+                      id={`debounce-seconds-${library.id}`}
+                      type="number"
+                      min={3}
+                      value={settingsForms[library.id]?.debounce_seconds ?? 15}
+                      onChange={(event) =>
+                        updateLibraryForm(library.id, {
+                          debounce_seconds: Number(event.target.value),
+                        })
+                      }
+                    />
+                  </div>
+                ) : null}
+                <div className="library-settings-actions">
+                  {libraryMessages[library.id] ? <div className="alert success">{libraryMessages[library.id]}</div> : null}
+                  <div className="toolbar">
+                    <button type="submit" className="secondary small">
+                      Save settings
+                    </button>
+                    <button
+                      type="button"
+                      className="small"
+                      onClick={() => void runLibraryScan(library.id, "incremental")}
+                    >
+                      Scan now
+                    </button>
+                    <button
+                      type="button"
+                      className="secondary small"
+                      onClick={() => void runLibraryScan(library.id, "full")}
+                    >
+                      Full scan
+                    </button>
+                  </div>
+                </div>
+              </form>
+            </div>
+          ))}
+        </div>
+      </AsyncPanel>
+
+      <AsyncPanel
+        title="Create library"
+        subtitle="Path selection is restricted to directories below MEDIA_ROOT."
+        error={submitError}
+      >
+        <form className="form-grid" onSubmit={handleSubmit}>
+          <div className="field">
+            <label htmlFor="library-name">Name</label>
+            <input
+              id="library-name"
+              value={form.name}
+              onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+              placeholder="Movies archive"
+              required
+            />
           </div>
-        </AsyncPanel>
-      </div>
+          <div className="field">
+            <label htmlFor="library-type">Library type</label>
+            <select
+              id="library-type"
+              value={form.type}
+              onChange={(event) => setForm((current) => ({ ...current, type: event.target.value }))}
+            >
+              <option value="movies">movies</option>
+              <option value="series">series</option>
+              <option value="mixed">mixed</option>
+              <option value="other">other</option>
+            </select>
+          </div>
+          <PathBrowser
+            value={form.path}
+            onChange={(path) => setForm((current) => ({ ...current, path }))}
+          />
+          <button type="submit" disabled={submitting}>
+            {submitting ? "Creating…" : "Create library"}
+          </button>
+        </form>
+      </AsyncPanel>
     </>
   );
 }

--- a/frontend/src/pages/LibraryDetailPage.tsx
+++ b/frontend/src/pages/LibraryDetailPage.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 
@@ -8,21 +9,244 @@ import { api, type LibraryDetail, type MediaFileRow, type ScanJob } from "../lib
 import { formatBytes, formatDate, formatDuration } from "../lib/format";
 import { useScanJobs } from "../lib/scan-jobs";
 
+type FileColumnKey =
+  | "file"
+  | "size"
+  | "video_codec"
+  | "resolution"
+  | "hdr_type"
+  | "duration"
+  | "audio_languages"
+  | "subtitle_languages"
+  | "scan_status"
+  | "mtime"
+  | "last_seen_at"
+  | "last_analyzed_at"
+  | "quality_score";
+
+type SortDirection = "asc" | "desc";
+
+type FileColumnDefinition = {
+  key: FileColumnKey;
+  label: string;
+  sticky?: boolean;
+  hideable?: boolean;
+  sortValue: (file: MediaFileRow) => number | string;
+  render: (file: MediaFileRow) => ReactNode;
+};
+
+const DEFAULT_VISIBLE_COLUMNS: FileColumnKey[] = [
+  "file",
+  "size",
+  "video_codec",
+  "resolution",
+  "duration",
+  "audio_languages",
+  "subtitle_languages",
+  "quality_score",
+];
+
+function joinValues(values: string[]): string {
+  return values.length > 0 ? values.join(", ") : "n/a";
+}
+
+function resolutionSortValue(resolution: string | null): number {
+  if (!resolution) {
+    return -1;
+  }
+  const match = /^(\d+)x(\d+)$/i.exec(resolution);
+  if (!match) {
+    return -1;
+  }
+  const width = Number(match[1]);
+  const height = Number(match[2]);
+  return width * height;
+}
+
+function timeSortValue(value: string | null): number {
+  if (!value) {
+    return 0;
+  }
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function scoreMeterLabel(score: number): string {
+  if (score <= 3) {
+    return "low";
+  }
+  if (score <= 6) {
+    return "medium";
+  }
+  return "high";
+}
+
+const FILE_COLUMNS: FileColumnDefinition[] = [
+  {
+    key: "file",
+    label: "File",
+    sticky: true,
+    hideable: false,
+    sortValue: (file) => file.relative_path.toLowerCase(),
+    render: (file) => (
+      <div className="media-file-cell">
+        <Link to={`/files/${file.id}`} className="file-link">
+          {file.filename}
+        </Link>
+        <small>{file.relative_path}</small>
+      </div>
+    ),
+  },
+  {
+    key: "size",
+    label: "Size",
+    sortValue: (file) => file.size_bytes,
+    render: (file) => formatBytes(file.size_bytes),
+  },
+  {
+    key: "video_codec",
+    label: "Codec",
+    sortValue: (file) => (file.video_codec ?? "").toLowerCase(),
+    render: (file) => file.video_codec ?? "n/a",
+  },
+  {
+    key: "resolution",
+    label: "Resolution",
+    sortValue: (file) => resolutionSortValue(file.resolution),
+    render: (file) => file.resolution ?? "n/a",
+  },
+  {
+    key: "hdr_type",
+    label: "HDR",
+    sortValue: (file) => (file.hdr_type ?? "").toLowerCase(),
+    render: (file) => file.hdr_type ?? "SDR",
+  },
+  {
+    key: "duration",
+    label: "Duration",
+    sortValue: (file) => file.duration ?? 0,
+    render: (file) => formatDuration(file.duration),
+  },
+  {
+    key: "audio_languages",
+    label: "Audio",
+    sortValue: (file) => joinValues(file.audio_languages).toLowerCase(),
+    render: (file) => joinValues(file.audio_languages),
+  },
+  {
+    key: "subtitle_languages",
+    label: "Subtitles",
+    sortValue: (file) => joinValues(file.subtitle_languages).toLowerCase(),
+    render: (file) => joinValues(file.subtitle_languages),
+  },
+  {
+    key: "scan_status",
+    label: "Status",
+    sortValue: (file) => file.scan_status.toLowerCase(),
+    render: (file) => file.scan_status,
+  },
+  {
+    key: "mtime",
+    label: "Modified",
+    sortValue: (file) => file.mtime,
+    render: (file) => formatDate(new Date(file.mtime * 1000).toISOString()),
+  },
+  {
+    key: "last_seen_at",
+    label: "Last seen",
+    sortValue: (file) => timeSortValue(file.last_seen_at),
+    render: (file) => formatDate(file.last_seen_at),
+  },
+  {
+    key: "last_analyzed_at",
+    label: "Last analyzed",
+    sortValue: (file) => timeSortValue(file.last_analyzed_at),
+    render: (file) => formatDate(file.last_analyzed_at),
+  },
+  {
+    key: "quality_score",
+    label: "Score",
+    sortValue: (file) => file.quality_score,
+    render: (file) => (
+      <div className="score-cell">
+        <strong>{file.quality_score}/10</strong>
+        <div className="score-meter" aria-hidden="true">
+          <span
+            className={`score-meter-fill score-meter-fill-${scoreMeterLabel(file.quality_score)}`}
+            style={{ width: `${Math.max(0, Math.min(10, file.quality_score)) * 10}%` }}
+          />
+        </div>
+      </div>
+    ),
+  },
+];
+
 export function LibraryDetailPage() {
   const { libraryId = "" } = useParams();
   const [library, setLibrary] = useState<LibraryDetail | null>(null);
   const [files, setFiles] = useState<MediaFileRow[]>([]);
   const [error, setError] = useState<string | null>(null);
-  const [scanState, setScanState] = useState<string | null>(null);
-  const [settingsState, setSettingsState] = useState<string | null>(null);
   const [scanHistory, setScanHistory] = useState<ScanJob[]>([]);
-  const [settingsForm, setSettingsForm] = useState({
-    scan_mode: "manual",
-    interval_minutes: 60,
-    debounce_seconds: 15,
-  });
-  const { activeJobs, hasActiveJobs, refresh } = useScanJobs();
+  const [visibleColumns, setVisibleColumns] = useState<FileColumnKey[]>(DEFAULT_VISIBLE_COLUMNS);
+  const [sortKey, setSortKey] = useState<FileColumnKey>("file");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+  const { activeJobs, hasActiveJobs } = useScanJobs();
   const activeJob = activeJobs.find((job) => String(job.library_id) === libraryId) ?? null;
+  const activeColumns = FILE_COLUMNS.filter((column) => visibleColumns.includes(column.key));
+  const sortedFiles = [...files].sort((left, right) => {
+    const column = FILE_COLUMNS.find((entry) => entry.key === sortKey);
+    if (!column) {
+      return 0;
+    }
+    const leftValue = column.sortValue(left);
+    const rightValue = column.sortValue(right);
+
+    let comparison = 0;
+    if (typeof leftValue === "number" && typeof rightValue === "number") {
+      comparison = leftValue - rightValue;
+    } else {
+      comparison = String(leftValue).localeCompare(String(rightValue), undefined, {
+        numeric: true,
+        sensitivity: "base",
+      });
+    }
+
+    if (comparison === 0) {
+      comparison = left.relative_path.localeCompare(right.relative_path, undefined, {
+        numeric: true,
+        sensitivity: "base",
+      });
+    }
+
+    return sortDirection === "asc" ? comparison : comparison * -1;
+  });
+
+  function toggleColumn(columnKey: FileColumnKey) {
+    const column = FILE_COLUMNS.find((entry) => entry.key === columnKey);
+    if (!column || column.hideable === false) {
+      return;
+    }
+    setVisibleColumns((current) => {
+      if (current.includes(columnKey)) {
+        if (sortKey === columnKey) {
+          setSortKey("file");
+          setSortDirection("asc");
+        }
+        return current.filter((entry) => entry !== columnKey);
+      }
+      const next = [...current, columnKey];
+      return FILE_COLUMNS.filter((entry) => next.includes(entry.key)).map((entry) => entry.key);
+    });
+  }
+
+  function updateSort(nextKey: FileColumnKey) {
+    if (sortKey === nextKey) {
+      setSortDirection((current) => (current === "asc" ? "desc" : "asc"));
+      return;
+    }
+    setSortKey(nextKey);
+    setSortDirection(nextKey === "quality_score" ? "desc" : "asc");
+  }
 
   function loadPage() {
     Promise.all([api.library(libraryId), api.libraryFiles(libraryId), api.libraryScanJobs(libraryId)])
@@ -30,11 +254,6 @@ export function LibraryDetailPage() {
         setLibrary(libraryPayload);
         setFiles(filesPayload);
         setScanHistory(scanJobsPayload);
-        setSettingsForm({
-          scan_mode: libraryPayload.scan_mode,
-          interval_minutes: Number(libraryPayload.scan_config.interval_minutes ?? 60),
-          debounce_seconds: Number(libraryPayload.scan_config.debounce_seconds ?? 15),
-        });
         setError(null);
       })
       .catch((reason: Error) => setError(reason.message));
@@ -52,71 +271,33 @@ export function LibraryDetailPage() {
     return () => window.clearInterval(timer);
   }, [hasActiveJobs, libraryId]);
 
-  async function triggerScan(scanType: string) {
-    try {
-      const job = await api.scanLibrary(libraryId, scanType);
-      setScanState(`Scan job #${job.id} queued as ${job.job_type}. Refresh after completion.`);
-      await refresh();
-      loadPage();
-    } catch (reason) {
-      setScanState((reason as Error).message);
-    }
-  }
-
-  async function saveSettings(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    try {
-      await api.updateLibrarySettings(libraryId, {
-        scan_mode: settingsForm.scan_mode,
-        scan_config:
-          settingsForm.scan_mode === "scheduled"
-            ? { interval_minutes: settingsForm.interval_minutes }
-            : settingsForm.scan_mode === "watch"
-              ? { debounce_seconds: settingsForm.debounce_seconds }
-              : {},
-      });
-      setSettingsState("Settings saved.");
-      loadPage();
-    } catch (reason) {
-      setSettingsState((reason as Error).message);
-    }
-  }
-
   return (
     <>
       <section className="panel stack">
-        <div className="detail-back">
-          <Link to="/libraries" className="badge">
-            Back to libraries
-          </Link>
-          <div className="toolbar">
-            <button type="button" className="secondary small" onClick={() => triggerScan("incremental")}>
-              Incremental scan
-            </button>
-            <button type="button" className="small" onClick={() => triggerScan("full")}>
-              Full scan
-            </button>
-          </div>
-        </div>
-        {scanState ? <div className="notice">{scanState}</div> : null}
         {activeJob ? (
           <div className="notice">
             <div className="distribution-copy">
-              <strong>{activeJob.phase_label}</strong>
-              <span>
-                {activeJob.files_total > 0
-                  ? `${activeJob.files_scanned}/${activeJob.files_total} files`
-                  : "Preparing scan"}
-              </span>
+              <strong>Scan in progress</strong>
+              <span>{activeJob.files_total > 0 ? `${activeJob.files_scanned}/${activeJob.files_total} files` : null}</span>
             </div>
             <div className="progress">
               <span style={{ width: `${activeJob.progress_percent}%` }} />
             </div>
           </div>
         ) : null}
-        <p className="eyebrow">Library analysis</p>
-        <h2>{library?.name ?? "Loading library…"}</h2>
-        <p className="subtitle">{library?.path}</p>
+        <div className="panel-title-row">
+          <h2>{library?.name ?? "Loading library…"}</h2>
+          {library?.path ? (
+            <span
+              className="tooltip-trigger"
+              tabIndex={0}
+              aria-label="Library path"
+              data-tooltip={library.path}
+            >
+              ?
+            </span>
+          ) : null}
+        </div>
         <div className="card-grid grid">
           <StatCard label="Files" value={String(library?.file_count ?? 0)} />
           <StatCard label="Storage" value={formatBytes(library?.total_size_bytes ?? 0)} tone="teal" />
@@ -130,103 +311,115 @@ export function LibraryDetailPage() {
       </section>
 
       <div className="media-grid">
-        <AsyncPanel title="Scan settings" loading={!library && !error} error={error}>
-          <form className="form-grid" onSubmit={saveSettings}>
-            <div className="field">
-              <label htmlFor="scan-mode">Mode</label>
-              <select
-                id="scan-mode"
-                value={settingsForm.scan_mode}
-                onChange={(event) =>
-                  setSettingsForm((current) => ({ ...current, scan_mode: event.target.value }))
-                }
-              >
-                <option value="manual">manual</option>
-                <option value="scheduled">scheduled</option>
-                <option value="watch">watch</option>
-              </select>
-            </div>
-            {settingsForm.scan_mode === "scheduled" ? (
-              <div className="field">
-                <label htmlFor="interval-minutes">Interval in minutes</label>
-                <input
-                  id="interval-minutes"
-                  type="number"
-                  min={5}
-                  value={settingsForm.interval_minutes}
-                  onChange={(event) =>
-                    setSettingsForm((current) => ({
-                      ...current,
-                      interval_minutes: Number(event.target.value),
-                    }))
-                  }
-                />
-              </div>
-            ) : null}
-            {settingsForm.scan_mode === "watch" ? (
-              <div className="field">
-                <label htmlFor="debounce-seconds">Debounce in seconds</label>
-                <input
-                  id="debounce-seconds"
-                  type="number"
-                  min={3}
-                  value={settingsForm.debounce_seconds}
-                  onChange={(event) =>
-                    setSettingsForm((current) => ({
-                      ...current,
-                      debounce_seconds: Number(event.target.value),
-                    }))
-                  }
-                />
-              </div>
-            ) : null}
-            <div className="notice">
-              <strong>Behavior</strong>
-              <p className="subtitle settings-copy">
-                `manual` only scans on demand. `scheduled` queues periodic incremental scans.
-                `watch` listens for file changes and debounces automatic incremental scans.
-              </p>
-            </div>
-            {settingsState ? <div className="alert success">{settingsState}</div> : null}
-            <button type="submit">Save settings</button>
-          </form>
+        <AsyncPanel
+          title="Video codecs"
+          loading={!library && !error}
+          error={error}
+          bodyClassName="async-panel-body-scroll"
+        >
+          <DistributionList
+            items={library?.video_codec_distribution ?? []}
+            maxVisibleRows={5}
+            scrollable
+          />
         </AsyncPanel>
-        <AsyncPanel title="Video codecs" loading={!library && !error} error={error}>
-          <DistributionList items={library?.video_codec_distribution ?? []} />
+        <AsyncPanel
+          title="Resolutions"
+          loading={!library && !error}
+          error={error}
+          bodyClassName="async-panel-body-scroll"
+        >
+          <DistributionList
+            items={library?.resolution_distribution ?? []}
+            maxVisibleRows={5}
+            scrollable
+          />
         </AsyncPanel>
-        <AsyncPanel title="Resolutions" loading={!library && !error} error={error}>
-          <DistributionList items={library?.resolution_distribution ?? []} />
+        <AsyncPanel
+          title="HDR coverage"
+          loading={!library && !error}
+          error={error}
+          bodyClassName="async-panel-body-scroll"
+        >
+          <DistributionList
+            items={library?.hdr_distribution ?? []}
+            maxVisibleRows={5}
+            scrollable
+          />
         </AsyncPanel>
-        <AsyncPanel title="HDR coverage" loading={!library && !error} error={error}>
-          <DistributionList items={library?.hdr_distribution ?? []} />
-        </AsyncPanel>
-        <AsyncPanel title="Audio languages" loading={!library && !error} error={error}>
-          <DistributionList items={library?.audio_language_distribution ?? []} />
+        <AsyncPanel
+          title="Audio languages"
+          loading={!library && !error}
+          error={error}
+          bodyClassName="async-panel-body-scroll"
+        >
+          <DistributionList
+            items={library?.audio_language_distribution ?? []}
+            maxVisibleRows={5}
+            scrollable
+          />
         </AsyncPanel>
       </div>
 
       <AsyncPanel title="Analyzed files" subtitle={`${files.length} indexed entries`} error={error}>
-        <div className="media-table">
-          <div className="media-table-head">
-            <span>File</span>
-            <span>Codec</span>
-            <span>Resolution</span>
-            <span>Duration</span>
-            <span>Score</span>
+        <div className="data-table-tools">
+          <div className="data-table-state">
+            <span className="badge">Sort: {FILE_COLUMNS.find((column) => column.key === sortKey)?.label ?? "File"}</span>
+            <span className="badge">{sortDirection}</span>
           </div>
-          {files.map((file) => (
-            <Link className="media-table-row" key={file.id} to={`/files/${file.id}`}>
-              <span>
-                <strong>{file.filename}</strong>
-                <small>{file.relative_path}</small>
-              </span>
-              <span>{file.video_codec ?? "n/a"}</span>
-              <span>{file.resolution ?? "n/a"}</span>
-              <span>{formatDuration(file.duration)}</span>
-              <span>{file.quality_score}/10</span>
-            </Link>
-          ))}
+          <div className="column-picker" aria-label="Visible metadata columns">
+            {FILE_COLUMNS.map((column) => {
+              const isVisible = visibleColumns.includes(column.key);
+              return (
+                <button
+                  key={column.key}
+                  type="button"
+                  className={`column-toggle${isVisible ? " is-active" : ""}`}
+                  onClick={() => toggleColumn(column.key)}
+                  disabled={column.hideable === false}
+                >
+                  {column.label}
+                </button>
+              );
+            })}
+          </div>
         </div>
+        {sortedFiles.length === 0 ? (
+          <div className="notice">No analyzed files yet.</div>
+        ) : (
+          <div className="data-table-shell">
+            <table className="media-data-table">
+              <thead>
+                <tr>
+                  {activeColumns.map((column) => {
+                    const isActiveSort = sortKey === column.key;
+                    return (
+                      <th key={column.key} className={column.sticky ? "is-sticky" : undefined} scope="col">
+                        <button type="button" className="column-sort" onClick={() => updateSort(column.key)}>
+                          <span>{column.label}</span>
+                          <span className={`sort-indicator${isActiveSort ? " is-active" : ""}`}>
+                            {isActiveSort ? sortDirection : "off"}
+                          </span>
+                        </button>
+                      </th>
+                    );
+                  })}
+                </tr>
+              </thead>
+              <tbody>
+                {sortedFiles.map((file) => (
+                  <tr key={file.id}>
+                    {activeColumns.map((column) => (
+                      <td key={column.key} className={column.sticky ? "is-sticky" : undefined}>
+                        {column.render(file)}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </AsyncPanel>
 
       <AsyncPanel title="Recent scan jobs" subtitle="Latest queue and run history" error={error}>
@@ -241,7 +434,7 @@ export function LibraryDetailPage() {
               </div>
               <div className="stack">
                 <span>
-                  {job.files_total > 0 ? `${job.files_scanned}/${job.files_total}` : "discovering"}
+                  {job.files_total > 0 ? `${job.files_scanned}/${job.files_total}` : null}
                 </span>
                 <div className="progress">
                   <span style={{ width: `${job.progress_percent}%` }} />

--- a/scripts/local_start.ps1
+++ b/scripts/local_start.ps1
@@ -46,6 +46,7 @@ $ConfigPath = if ($env:CONFIG_PATH) { $env:CONFIG_PATH } else { Join-Path $RootD
 $MediaRoot = if ($env:MEDIA_ROOT) { $env:MEDIA_ROOT } else { Join-Path $RootDir "media" }
 $AppPort = if ($env:APP_PORT) { $env:APP_PORT } else { "8080" }
 $VitePort = if ($env:VITE_PORT) { $env:VITE_PORT } else { "5173" }
+$TimeZone = if ($env:TZ) { $env:TZ } else { "UTC" }
 $VenvDir = Join-Path $RootDir ".venv"
 $PythonExe = Join-Path $VenvDir "Scripts\python.exe"
 $BackendStamp = Join-Path $VenvDir ".backend-deps.stamp"
@@ -79,6 +80,7 @@ if ($NeedsFrontendInstall) {
 $env:CONFIG_PATH = $ConfigPath
 $env:MEDIA_ROOT = $MediaRoot
 $env:APP_PORT = $AppPort
+$env:TZ = $TimeZone
 
 $BackendProcess = Start-Process -FilePath $PythonExe -ArgumentList @("-m", "uvicorn", "backend.app.main:app", "--reload", "--host", "127.0.0.1", "--port", $AppPort) -PassThru
 $FrontendProcess = Start-Process -FilePath "npm" -ArgumentList @("run", "dev", "--", "--host", "127.0.0.1", "--port", $VitePort) -WorkingDirectory (Join-Path $RootDir "frontend") -PassThru
@@ -87,6 +89,7 @@ Write-Host "Backend:  http://127.0.0.1:$AppPort"
 Write-Host "Frontend: http://127.0.0.1:$VitePort"
 Write-Host "CONFIG_PATH=$ConfigPath"
 Write-Host "MEDIA_ROOT=$MediaRoot"
+Write-Host "TZ=$TimeZone"
 Write-Host ".env loaded: $(Test-Path (Join-Path $RootDir '.env'))"
 Write-Host "Press Ctrl+C to stop both processes."
 

--- a/scripts/local_start.sh
+++ b/scripts/local_start.sh
@@ -15,6 +15,7 @@ CONFIG_PATH="${CONFIG_PATH:-$ROOT_DIR/config}"
 MEDIA_ROOT="${MEDIA_ROOT:-$ROOT_DIR/media}"
 APP_PORT="${APP_PORT:-8080}"
 VITE_PORT="${VITE_PORT:-5173}"
+TZ="${TZ:-UTC}"
 VENV_DIR="$ROOT_DIR/.venv"
 PYTHON_BIN="$VENV_DIR/bin/python"
 PIP_BIN="$VENV_DIR/bin/pip"
@@ -55,6 +56,7 @@ trap cleanup EXIT INT TERM
 export CONFIG_PATH
 export MEDIA_ROOT
 export APP_PORT
+export TZ
 
 "$PYTHON_BIN" -m uvicorn backend.app.main:app --reload --host 127.0.0.1 --port "$APP_PORT" &
 BACKEND_PID=$!
@@ -69,6 +71,7 @@ printf 'Backend:  http://127.0.0.1:%s\n' "$APP_PORT"
 printf 'Frontend: http://127.0.0.1:%s\n' "$VITE_PORT"
 printf 'CONFIG_PATH=%s\n' "$CONFIG_PATH"
 printf 'MEDIA_ROOT=%s\n' "$MEDIA_ROOT"
+printf 'TZ=%s\n' "$TZ"
 
 while kill -0 "$BACKEND_PID" 2>/dev/null && kill -0 "$FRONTEND_PID" 2>/dev/null; do
   sleep 1

--- a/tests/test_ffprobe_parser.py
+++ b/tests/test_ffprobe_parser.py
@@ -49,6 +49,37 @@ def test_normalize_ffprobe_payload_extracts_streams() -> None:
     assert normalized.media_format.duration == 5423.21
     assert normalized.video_streams[0].hdr_type == "HDR10"
     assert normalized.video_streams[0].frame_rate == 24000 / 1001
-    assert normalized.audio_streams[0].language == "eng"
+    assert normalized.audio_streams[0].language == "en"
+    assert normalized.subtitle_streams[0].language == "de"
     assert normalized.subtitle_streams[0].subtitle_type == "text"
 
+
+def test_normalize_ffprobe_payload_ignores_attached_pictures() -> None:
+    payload = {
+        "format": {"format_name": "matroska"},
+        "streams": [
+            {
+                "index": 0,
+                "codec_type": "video",
+                "codec_name": "h264",
+                "width": 1920,
+                "height": 1080,
+                "avg_frame_rate": "24/1",
+                "disposition": {"attached_pic": 0},
+            },
+            {
+                "index": 1,
+                "codec_type": "video",
+                "codec_name": "mjpeg",
+                "width": 600,
+                "height": 900,
+                "avg_frame_rate": "0/0",
+                "disposition": {"attached_pic": 1},
+            },
+        ],
+    }
+
+    normalized = normalize_ffprobe_payload(payload)
+
+    assert len(normalized.video_streams) == 1
+    assert normalized.video_streams[0].codec == "h264"

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,0 +1,113 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from backend.app.db.base import Base
+from backend.app.models.entities import AudioStream, Library, LibraryType, MediaFile, MediaFormat, ScanMode, ScanStatus, VideoStream
+from backend.app.services.stats import build_dashboard
+
+
+def test_dashboard_counts_primary_video_only() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    with session_factory() as db:
+        library = Library(
+            name="Movies",
+            path="/tmp/movies",
+            type=LibraryType.movies,
+            scan_mode=ScanMode.manual,
+            scan_config={},
+        )
+        db.add(library)
+        db.flush()
+
+        media_file = MediaFile(
+            library_id=library.id,
+            relative_path="movie.mkv",
+            filename="movie.mkv",
+            extension="mkv",
+            size_bytes=123,
+            mtime=1.0,
+            scan_status=ScanStatus.ready,
+            quality_score=5,
+        )
+        db.add(media_file)
+        db.flush()
+        db.add(MediaFormat(media_file_id=media_file.id, duration=120.0))
+        db.add_all(
+            [
+                VideoStream(
+                    media_file_id=media_file.id,
+                    stream_index=0,
+                    codec="h264",
+                    width=1920,
+                    height=1080,
+                    hdr_type=None,
+                ),
+                VideoStream(
+                    media_file_id=media_file.id,
+                    stream_index=1,
+                    codec="hevc",
+                    width=3840,
+                    height=2160,
+                    hdr_type="HDR10",
+                ),
+            ]
+        )
+        db.commit()
+
+        dashboard = build_dashboard(db)
+
+    assert dashboard.video_codec_distribution[0].label == "h264"
+    assert dashboard.video_codec_distribution[0].value == 1
+    assert all(item.label != "hevc" for item in dashboard.video_codec_distribution)
+
+
+def test_dashboard_merges_common_audio_language_aliases() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    with session_factory() as db:
+        library = Library(
+            name="Movies",
+            path="/tmp/movies",
+            type=LibraryType.movies,
+            scan_mode=ScanMode.manual,
+            scan_config={},
+        )
+        db.add(library)
+        db.flush()
+
+        media_file = MediaFile(
+            library_id=library.id,
+            relative_path="movie.mkv",
+            filename="movie.mkv",
+            extension="mkv",
+            size_bytes=123,
+            mtime=1.0,
+            scan_status=ScanStatus.ready,
+            quality_score=5,
+        )
+        db.add(media_file)
+        db.flush()
+        db.add_all(
+            [
+                AudioStream(media_file_id=media_file.id, stream_index=1, codec="aac", language="deu"),
+                AudioStream(media_file_id=media_file.id, stream_index=2, codec="aac", language="ger"),
+                AudioStream(media_file_id=media_file.id, stream_index=3, codec="aac", language="de"),
+                AudioStream(media_file_id=media_file.id, stream_index=4, codec="aac", language="eng"),
+                AudioStream(media_file_id=media_file.id, stream_index=5, codec="aac", language="en-US"),
+            ]
+        )
+        db.commit()
+
+        dashboard = build_dashboard(db)
+
+    audio_languages = {item.label: item.value for item in dashboard.audio_language_distribution}
+    assert audio_languages["de"] == 3
+    assert audio_languages["en"] == 2
+    assert "deu" not in audio_languages
+    assert "ger" not in audio_languages
+    assert "eng" not in audio_languages

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -7,13 +7,14 @@ def test_detect_external_subtitles_matches_sibling_files(tmp_path: Path) -> None
     video = tmp_path / "movie.mkv"
     video.write_text("video")
     (tmp_path / "movie.en.srt").write_text("sub")
-    (tmp_path / "movie.de.ass").write_text("sub")
+    (tmp_path / "movie.ger.ass").write_text("sub")
+    (tmp_path / "movie.de-DE.ssa").write_text("sub")
     (tmp_path / "other.en.srt").write_text("sub")
 
-    subtitles = detect_external_subtitles(video, (".srt", ".ass"))
+    subtitles = detect_external_subtitles(video, (".srt", ".ass", ".ssa"))
 
     assert subtitles == [
-        {"path": "movie.de.ass", "language": "de", "format": "ass"},
+        {"path": "movie.de-DE.ssa", "language": "de", "format": "ssa"},
         {"path": "movie.en.srt", "language": "en", "format": "srt"},
+        {"path": "movie.ger.ass", "language": "de", "format": "ass"},
     ]
-


### PR DESCRIPTION
## Summary
- Normalize audio/subtitle language codes across ffprobe parsing, subtitle hint detection, media rows, and aggregated distributions.
- Add shared language utilities (`normalize_language_code`, `normalize_language_hint`, `merge_language_counts`) to remove duplicate logic and unify fallback handling (`und`).
- Compute dashboard and library video stats from primary video streams only (excluding attached pictures) via a dedicated query helper.
- Standardize timestamps to timezone-aware UTC (`utc_now`) and add configurable `TZ` support in env/docs/runtime container setup.
- Update Docker build/runtime flow (`npm ci`, slimmer runtime copy/install set) and refresh frontend navigation/UI structure for library-centric routing.
- Expand tests for parser/stats/subtitles to cover normalized languages and primary-stream stat behavior.

## Testing
- Added/updated unit tests in `tests/test_ffprobe_parser.py` for attached picture filtering and language normalization.
- Added `tests/test_stats.py` coverage for primary video stream aggregation and normalized language distributions.
- Updated `tests/test_subtitles.py` to validate normalized external subtitle language hints.
- Not run: full backend/frontend test suites in this PR context.