### PR TITLE
Normalize language handling and primary-video stats; refresh table/nav UI

### DIFF
--- a/frontend/src/medialyze.css
+++ b/frontend/src/medialyze.css
@@ -398,7 +398,7 @@
   position: sticky;
   top: 0;
   z-index: 2;
-  background: rgba(243, 239, 232, 0.96);
+  background: #f6f1ea;
 }
 
 .media-data-table tbody tr:last-child td {
@@ -413,12 +413,12 @@
   position: sticky;
   left: 0;
   z-index: 1;
-  background: inherit;
+  background: rgba(255, 255, 255, 0.72);
 }
 
 .media-data-table thead .is-sticky {
   z-index: 3;
-  background: rgba(243, 239, 232, 0.98);
+  background: #f6f1ea;
 }
 
 .column-sort {


### PR DESCRIPTION
## Summary
- Normalize audio/subtitle language codes across ffprobe parsing, subtitle detection, media responses, and aggregated stats.
- Compute dashboard and library video metrics from the primary video stream only, and ignore attached-picture video streams.
- Add shared helpers for language normalization/merging and primary video stream SQL subqueries.
- Standardize backend timestamps on timezone-aware UTC datetimes and add configurable `TZ` runtime/container support.
- Update Docker build/runtime setup (`npm ci`, slimmer runtime deps, `tzdata`) and propagate `TZ` through compose/env docs.
- Improve frontend UX with updated app navigation, async panel header addons, sticky/column table styling improvements, and library/detail page UI refinements.
- Add/adjust tests for ffprobe parsing, subtitle handling, and stats language aggregation behavior.

## Testing
- Not run (test execution was not provided in this diff context).
- Added coverage in `tests/test_stats.py` for language-count normalization/aggregation behavior.
- Updated parser/subtitle tests (`tests/test_ffprobe_parser.py`, `tests/test_subtitles.py`) to validate normalized language handling and related parsing behavior.