### PR TITLE
remove cdrom,usb,floppy shadow directories

### DIFF
--- a/backend/app/services/browse.py
+++ b/backend/app/services/browse.py
@@ -4,19 +4,29 @@ from backend.app.core.config import Settings
 from backend.app.schemas.browse import BrowseEntry, BrowseResponse
 from backend.app.utils.pathing import ensure_relative_to_root, relative_display_path
 
+_CONTAINER_PLACEHOLDER_DIRS = frozenset({"cdrom", "floppy", "usb"})
+
+
+def _is_container_placeholder_dir(entry: Path, root: Path) -> bool:
+    if entry.name not in _CONTAINER_PLACEHOLDER_DIRS:
+        return False
+
+    try:
+        if entry.parent.resolve() != root.resolve():
+            return False
+        if root.is_mount():
+            return False
+        return entry.is_dir() and not entry.is_mount()
+    except OSError:
+        return False
+
 
 def _is_visible_browse_entry(entry: Path, root: Path) -> bool:
     try:
         ensure_relative_to_root(entry, root)
     except (OSError, ValueError):
         return False
-
-    # Docker can expose nested runtime mounts below MEDIA_ROOT. Hide those so the
-    # browser reflects only the configured media tree.
-    try:
-        return not entry.is_mount()
-    except OSError:
-        return False
+    return not _is_container_placeholder_dir(entry, root)
 
 
 def browse_media_root(settings: Settings, relative_path: str = ".") -> BrowseResponse:

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -4,15 +4,15 @@ from backend.app.core.config import Settings
 from backend.app.services.browse import browse_media_root
 
 
-def test_browse_media_root_hides_nested_mount_points(tmp_path: Path, monkeypatch) -> None:
+def test_browse_media_root_hides_container_placeholder_dirs(tmp_path: Path, monkeypatch) -> None:
     (tmp_path / "movies").mkdir()
     (tmp_path / "usb").mkdir()
 
     original_is_mount = Path.is_mount
 
     def fake_is_mount(self: Path) -> bool:
-        if self == tmp_path / "usb":
-            return True
+        if self == tmp_path:
+            return False
         return original_is_mount(self)
 
     monkeypatch.setattr(Path, "is_mount", fake_is_mount)
@@ -20,6 +20,26 @@ def test_browse_media_root_hides_nested_mount_points(tmp_path: Path, monkeypatch
     response = browse_media_root(Settings(config_path=tmp_path / "config", media_root=tmp_path))
 
     assert [entry.name for entry in response.entries] == ["movies"]
+
+
+def test_browse_media_root_keeps_explicit_mounts_visible(tmp_path: Path, monkeypatch) -> None:
+    (tmp_path / "movies").mkdir()
+    (tmp_path / "disk1").mkdir()
+
+    original_is_mount = Path.is_mount
+
+    def fake_is_mount(self: Path) -> bool:
+        if self == tmp_path / "disk1":
+            return True
+        if self == tmp_path:
+            return False
+        return original_is_mount(self)
+
+    monkeypatch.setattr(Path, "is_mount", fake_is_mount)
+
+    response = browse_media_root(Settings(config_path=tmp_path / "config", media_root=tmp_path))
+
+    assert [entry.name for entry in response.entries] == ["disk1", "movies"]
 
 
 def test_browse_media_root_skips_symlinks_outside_media_root(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

The code now hides container placeholder directories when they are not mounted.

## Changes

- Modified visibility logic to exclude unmounted container placeholder directories

## Testing

- Added tests to verify that unmounted container placeholder directories are hidden and that explicit mounts remain visible

## Checklist

- [x] I tested the change locally.
- [x] I updated docs if behavior/config changed.
- [x] I kept the scope focused (single concern).
- [x] I did not include secrets or local machine artifacts.

