### PR TITLE
Add UTC datetime handling and fix tooltip button styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - fix: serialize API timestamps as explicit UTC `Z` values and restore SQLite datetime fields as UTC so the browser can render scan and library times in the user's local timezone ([#66](https://github.com/frederikemmer/MediaLyze/issues/66))
+- fix: align clickable statistics with table - counted streams instead of files ([#67](https://github.com/frederikemmer/MediaLyze/issues/67))
 
 ## v0.2.4
 

--- a/backend/app/services/library_service.py
+++ b/backend/app/services/library_service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from copy import deepcopy
 
-from sqlalchemy import case, delete, func, select
+from sqlalchemy import case, delete, distinct, func, literal, select, union_all
 from sqlalchemy.orm import Session
 
 from backend.app.core.config import Settings
@@ -21,7 +21,7 @@ from backend.app.models.entities import (
 from backend.app.schemas.library import LibraryCreate, LibraryStatistics, LibrarySummary, LibraryUpdate
 from backend.app.schemas.media import DistributionItem
 from backend.app.services.app_settings import get_app_settings as load_app_settings
-from backend.app.services.languages import merge_language_counts
+from backend.app.services.languages import normalize_language_code
 from backend.app.services.path_access import is_watch_supported_for_library, resolve_library_path
 from backend.app.services.quality import normalize_quality_profile
 from backend.app.services.resolution_categories import classify_resolution_category
@@ -90,6 +90,32 @@ def _distribution_items(rows: list[tuple[str | None, int]], *, fallback: str = "
         for label, value in rows
         if value > 0
     ]
+
+
+def _normalized_language_expr(expression):
+    candidate = func.lower(func.trim(func.coalesce(expression, "")))
+    return case((func.length(candidate) == 0, "und"), else_=candidate)
+
+
+def _normalized_text_expr(expression, fallback: str):
+    candidate = func.lower(func.trim(func.coalesce(expression, "")))
+    return case((func.length(candidate) == 0, fallback), else_=candidate)
+
+
+def _count_distinct_normalized_languages(
+    rows: list[tuple[int, str | None]] | tuple[tuple[int, str | None], ...],
+    *,
+    fallback: str = "und",
+) -> list[tuple[str, int]]:
+    values_by_file: dict[int, set[str]] = defaultdict(set)
+    for media_file_id, raw_value in rows:
+        values_by_file[media_file_id].add(normalize_language_code(raw_value) or fallback)
+
+    counts: dict[str, int] = defaultdict(int)
+    for values in values_by_file.values():
+        for value in values:
+            counts[value] += 1
+    return _sorted_count_items(counts)
 
 
 def normalize_scan_config(scan_mode, scan_config: dict | None) -> dict:
@@ -335,81 +361,110 @@ def get_library_statistics(db: Session, library_id: int) -> LibraryStatistics | 
         .group_by(func.coalesce(primary_video_streams.c.hdr_type, "SDR"))
         .order_by(func.count(primary_video_streams.c.id).desc())
     ).all()
-    audio_language_distribution = db.execute(
-        select(AudioStream.language, func.count(AudioStream.id))
+    audio_language_values = (
+        select(
+            AudioStream.media_file_id.label("media_file_id"),
+            _normalized_language_expr(AudioStream.language).label("value"),
+        )
         .join(MediaFile, MediaFile.id == AudioStream.media_file_id)
         .where(MediaFile.library_id == library_id)
-        .group_by(AudioStream.language)
-        .order_by(func.count(AudioStream.id).desc())
-    ).all()
+        .distinct()
+        .subquery("library_audio_language_values")
+    )
+    audio_language_distribution = _count_distinct_normalized_languages(
+        db.execute(
+            select(audio_language_values.c.media_file_id, audio_language_values.c.value)
+        ).all(),
+        fallback="und",
+    )
+    audio_codec_values = (
+        select(
+            AudioStream.media_file_id.label("media_file_id"),
+            _normalized_text_expr(AudioStream.codec, "unknown").label("value"),
+        )
+        .join(MediaFile, MediaFile.id == AudioStream.media_file_id)
+        .where(MediaFile.library_id == library_id)
+        .distinct()
+        .subquery()
+    )
     audio_codec_distribution = db.execute(
-        select(AudioStream.codec, func.count(AudioStream.id))
-        .join(MediaFile, MediaFile.id == AudioStream.media_file_id)
-        .where(MediaFile.library_id == library_id)
-        .group_by(AudioStream.codec)
-        .order_by(func.count(AudioStream.id).desc())
+        select(
+            audio_codec_values.c.value,
+            func.count(distinct(audio_codec_values.c.media_file_id)),
+        )
+        .group_by(audio_codec_values.c.value)
+        .order_by(func.count(distinct(audio_codec_values.c.media_file_id)).desc())
     ).all()
 
-    subtitle_counts: dict[str, int] = defaultdict(int)
-    for language, count in merge_language_counts(
-        db.execute(
-            select(SubtitleStream.language, func.count(SubtitleStream.id))
-            .join(MediaFile, MediaFile.id == SubtitleStream.media_file_id)
-            .where(MediaFile.library_id == library_id)
-            .group_by(SubtitleStream.language)
-        ).all(),
-        fallback="und",
-    ):
-        subtitle_counts[language] += count
-    for language, count in merge_language_counts(
-        db.execute(
-            select(ExternalSubtitle.language, func.count(ExternalSubtitle.id))
-            .join(MediaFile, MediaFile.id == ExternalSubtitle.media_file_id)
-            .where(MediaFile.library_id == library_id)
-            .group_by(ExternalSubtitle.language)
-        ).all(),
-        fallback="und",
-    ):
-        subtitle_counts[language] += count
-
-    subtitle_codec_counts: dict[str, int] = defaultdict(int)
-    for codec, count in db.execute(
-        select(SubtitleStream.codec, func.count(SubtitleStream.id))
-        .join(MediaFile, MediaFile.id == SubtitleStream.media_file_id)
-        .where(MediaFile.library_id == library_id)
-        .group_by(SubtitleStream.codec)
-        .order_by(func.count(SubtitleStream.id).desc())
-    ).all():
-        subtitle_codec_counts[_normalize_subtitle_codec(codec)] += count
-    for codec, count in db.execute(
-        select(ExternalSubtitle.format, func.count(ExternalSubtitle.id))
-        .join(MediaFile, MediaFile.id == ExternalSubtitle.media_file_id)
-        .where(MediaFile.library_id == library_id)
-        .group_by(ExternalSubtitle.format)
-        .order_by(func.count(ExternalSubtitle.id).desc())
-    ).all():
-        subtitle_codec_counts[_normalize_subtitle_codec(codec)] += count
-
-    subtitle_source_distribution = [
-        DistributionItem(
-            label="internal",
-            value=db.scalar(
-                select(func.count(SubtitleStream.id))
-                .join(MediaFile, MediaFile.id == SubtitleStream.media_file_id)
-                .where(MediaFile.library_id == library_id)
-            )
-            or 0,
+    subtitle_language_values = union_all(
+        select(
+            SubtitleStream.media_file_id.label("media_file_id"),
+            _normalized_language_expr(SubtitleStream.language).label("value"),
         ),
-        DistributionItem(
-            label="external",
-            value=db.scalar(
-                select(func.count(ExternalSubtitle.id))
-                .join(MediaFile, MediaFile.id == ExternalSubtitle.media_file_id)
-                .where(MediaFile.library_id == library_id)
-            )
-            or 0,
+        select(
+            ExternalSubtitle.media_file_id.label("media_file_id"),
+            _normalized_language_expr(ExternalSubtitle.language).label("value"),
         ),
-    ]
+    ).subquery("library_subtitle_language_values")
+    subtitle_codec_values = union_all(
+        select(
+            SubtitleStream.media_file_id.label("media_file_id"),
+            _normalized_text_expr(SubtitleStream.codec, "unknown").label("value"),
+        ),
+        select(
+            ExternalSubtitle.media_file_id.label("media_file_id"),
+            _normalized_text_expr(ExternalSubtitle.format, "unknown").label("value"),
+        ),
+    ).subquery("library_subtitle_codec_values")
+    subtitle_source_values = union_all(
+        select(SubtitleStream.media_file_id.label("media_file_id"), literal("internal").label("value")),
+        select(ExternalSubtitle.media_file_id.label("media_file_id"), literal("external").label("value")),
+    ).subquery("library_subtitle_source_values")
+
+    subtitle_counts = dict(
+        _count_distinct_normalized_languages(
+            db.execute(
+                select(subtitle_language_values.c.media_file_id, subtitle_language_values.c.value)
+                .join(MediaFile, MediaFile.id == subtitle_language_values.c.media_file_id)
+                .where(MediaFile.library_id == library_id)
+            ).all(),
+            fallback="und",
+        )
+    )
+
+    subtitle_codec_counts = dict(
+        db.execute(
+            select(
+                subtitle_codec_values.c.value,
+                func.count(distinct(subtitle_codec_values.c.media_file_id)),
+            )
+            .join(MediaFile, MediaFile.id == subtitle_codec_values.c.media_file_id)
+            .where(MediaFile.library_id == library_id)
+            .group_by(subtitle_codec_values.c.value)
+            .order_by(func.count(distinct(subtitle_codec_values.c.media_file_id)).desc())
+        ).all()
+    )
+
+    subtitle_source_distinct_values = (
+        select(
+            subtitle_source_values.c.media_file_id,
+            subtitle_source_values.c.value,
+        )
+        .join(MediaFile, MediaFile.id == subtitle_source_values.c.media_file_id)
+        .where(MediaFile.library_id == library_id)
+        .distinct()
+        .subquery("library_subtitle_source_distinct_values")
+    )
+    subtitle_source_distribution = _distribution_items(
+        db.execute(
+            select(
+                subtitle_source_distinct_values.c.value,
+                func.count(distinct(subtitle_source_distinct_values.c.media_file_id)),
+            )
+            .group_by(subtitle_source_distinct_values.c.value)
+            .order_by(func.count(distinct(subtitle_source_distinct_values.c.media_file_id)).desc())
+        ).all()
+    )
 
     payload = LibraryStatistics(
         video_codec_distribution=_distribution_items(video_codec_distribution),
@@ -418,13 +473,10 @@ def get_library_statistics(db: Session, library_id: int) -> LibraryStatistics | 
             resolution_categories=app_settings.resolution_categories,
         ),
         hdr_distribution=_distribution_items(hdr_distribution, fallback="SDR"),
-        audio_codec_distribution=[
-            DistributionItem(label=_normalize_audio_codec(key), value=value)
-            for key, value in audio_codec_distribution
-        ],
+        audio_codec_distribution=_distribution_items(audio_codec_distribution),
         audio_language_distribution=[
             DistributionItem(label=key, value=value)
-            for key, value in merge_language_counts(audio_language_distribution, fallback="und")
+            for key, value in audio_language_distribution
         ],
         subtitle_language_distribution=[
             DistributionItem(label=key, value=value)
@@ -434,9 +486,7 @@ def get_library_statistics(db: Session, library_id: int) -> LibraryStatistics | 
             DistributionItem(label=key, value=value)
             for key, value in _sorted_count_items(subtitle_codec_counts)
         ],
-        subtitle_source_distribution=[
-            item for item in subtitle_source_distribution if item.value > 0
-        ],
+        subtitle_source_distribution=subtitle_source_distribution,
     )
     stats_cache.set_library_statistics(cache_key, library_id, payload)
     return payload

--- a/backend/app/services/media_service.py
+++ b/backend/app/services/media_service.py
@@ -137,19 +137,38 @@ def _row_from_model(media_file: MediaFile, resolution_categories=None) -> MediaF
 
 
 def _audio_aggregate_subquery(name: str = "audio_aggregates"):
-    return (
+    normalized_language = func.lower(func.trim(func.coalesce(AudioStream.language, "")))
+    normalized_language = case(
+        (func.length(normalized_language) == 0, "und"),
+        else_=normalized_language,
+    )
+    normalized_codec = func.lower(func.trim(func.coalesce(AudioStream.codec, "")))
+    normalized_codec = case(
+        (func.length(normalized_codec) == 0, "unknown"),
+        else_=normalized_codec,
+    )
+    distinct_values = (
         select(
             AudioStream.media_file_id.label("media_file_id"),
-            func.coalesce(func.min(func.lower(AudioStream.language)), "").label("min_audio_language"),
-            func.coalesce(func.min(func.lower(AudioStream.codec)), "").label("min_audio_codec"),
-            func.coalesce(func.group_concat(func.lower(func.coalesce(AudioStream.language, "")), " "), "").label(
+            normalized_language.label("language"),
+            normalized_codec.label("codec"),
+        )
+        .distinct()
+        .subquery(f"{name}_distinct_values")
+    )
+    return (
+        select(
+            distinct_values.c.media_file_id.label("media_file_id"),
+            func.coalesce(func.min(distinct_values.c.language), "").label("min_audio_language"),
+            func.coalesce(func.min(distinct_values.c.codec), "").label("min_audio_codec"),
+            func.coalesce(func.group_concat(distinct_values.c.language, " "), "").label(
                 "audio_languages_search"
             ),
-            func.coalesce(func.group_concat(func.lower(func.coalesce(AudioStream.codec, "")), " "), "").label(
+            func.coalesce(func.group_concat(distinct_values.c.codec, " "), "").label(
                 "audio_codecs_search"
             ),
         )
-        .group_by(AudioStream.media_file_id)
+        .group_by(distinct_values.c.media_file_id)
         .subquery(name)
     )
 
@@ -192,22 +211,48 @@ def _subtitle_aggregate_subquery(name: str = "subtitle_aggregates"):
         select(ExternalSubtitle.media_file_id.label("media_file_id")),
     ).subquery(f"{name}_file_ids")
 
+    normalized_language_value = func.lower(func.trim(func.coalesce(language_values.c.value, "")))
+    normalized_language_value = case(
+        (func.length(normalized_language_value) == 0, "und"),
+        else_=normalized_language_value,
+    )
+    normalized_codec_value = func.lower(func.trim(func.coalesce(codec_values.c.value, "")))
+    normalized_codec_value = case(
+        (func.length(normalized_codec_value) == 0, "unknown"),
+        else_=normalized_codec_value,
+    )
+    distinct_language_values = (
+        select(
+            language_values.c.media_file_id.label("media_file_id"),
+            normalized_language_value.label("value"),
+        )
+        .distinct()
+        .subquery(f"{name}_distinct_language_values")
+    )
+    distinct_codec_values = (
+        select(
+            codec_values.c.media_file_id.label("media_file_id"),
+            normalized_codec_value.label("value"),
+        )
+        .distinct()
+        .subquery(f"{name}_distinct_codec_values")
+    )
     language_aggregates = (
         select(
-            language_values.c.media_file_id,
-            func.coalesce(func.min(language_values.c.value), "").label("min_subtitle_language"),
-            func.coalesce(func.group_concat(language_values.c.value, " "), "").label("subtitle_languages_search"),
+            distinct_language_values.c.media_file_id,
+            func.coalesce(func.min(distinct_language_values.c.value), "").label("min_subtitle_language"),
+            func.coalesce(func.group_concat(distinct_language_values.c.value, " "), "").label("subtitle_languages_search"),
         )
-        .group_by(language_values.c.media_file_id)
+        .group_by(distinct_language_values.c.media_file_id)
         .subquery(f"{name}_language_aggregates")
     )
     codec_aggregates = (
         select(
-            codec_values.c.media_file_id,
-            func.coalesce(func.min(codec_values.c.value), "").label("min_subtitle_codec"),
-            func.coalesce(func.group_concat(codec_values.c.value, " "), "").label("subtitle_codecs_search"),
+            distinct_codec_values.c.media_file_id,
+            func.coalesce(func.min(distinct_codec_values.c.value), "").label("min_subtitle_codec"),
+            func.coalesce(func.group_concat(distinct_codec_values.c.value, " "), "").label("subtitle_codecs_search"),
         )
-        .group_by(codec_values.c.media_file_id)
+        .group_by(distinct_codec_values.c.media_file_id)
         .subquery(f"{name}_codec_aggregates")
     )
     source_aggregates = (

--- a/backend/app/services/stats.py
+++ b/backend/app/services/stats.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlalchemy import func, select
+from sqlalchemy import distinct, func, select, union_all
 from sqlalchemy.orm import Session
 
 from backend.app.models.entities import (
@@ -14,7 +14,7 @@ from backend.app.models.entities import (
 )
 from backend.app.services.app_settings import get_app_settings
 from backend.app.schemas.media import DashboardResponse, DistributionItem
-from backend.app.services.languages import merge_language_counts
+from backend.app.services.languages import merge_language_counts, normalize_language_code
 from backend.app.services.resolution_categories import classify_resolution_category
 from backend.app.services.stats_cache import stats_cache
 from backend.app.services.video_queries import primary_video_streams_subquery
@@ -26,6 +26,32 @@ def _distribution(rows: list[tuple[str | None, int]], fallback: str = "unknown")
         for label, value in rows
         if value > 0
     ]
+
+
+def _normalized_language_expr(expression):
+    candidate = func.lower(func.trim(func.coalesce(expression, "")))
+    return func.coalesce(func.nullif(candidate, ""), "und")
+
+
+def _normalized_text_expr(expression, fallback: str):
+    candidate = func.lower(func.trim(func.coalesce(expression, "")))
+    return func.coalesce(func.nullif(candidate, ""), fallback)
+
+
+def _count_distinct_normalized_languages(
+    rows: list[tuple[int, str | None]] | tuple[tuple[int, str | None], ...],
+    *,
+    fallback: str = "und",
+) -> list[tuple[str, int]]:
+    values_by_file: dict[int, set[str]] = {}
+    for media_file_id, raw_value in rows:
+        values_by_file.setdefault(media_file_id, set()).add(normalize_language_code(raw_value) or fallback)
+
+    counts: dict[str, int] = {}
+    for values in values_by_file.values():
+        for value in values:
+            counts[value] = counts.get(value, 0) + 1
+    return sorted(counts.items(), key=lambda item: (-item[1], item[0]))
 
 
 def _resolution_label(width: int | None, height: int | None) -> str:
@@ -87,20 +113,47 @@ def build_dashboard(db: Session) -> DashboardResponse:
         .group_by(func.coalesce(primary_video_streams.c.hdr_type, "SDR"))
         .order_by(func.count(primary_video_streams.c.id).desc())
     ).all()
+    audio_codec_values = (
+        select(
+            AudioStream.media_file_id.label("media_file_id"),
+            _normalized_text_expr(AudioStream.codec, "unknown").label("value"),
+        )
+        .distinct()
+        .subquery("dashboard_audio_codec_values")
+    )
     audio_codec_rows = db.execute(
-        select(AudioStream.codec, func.count(AudioStream.id))
-        .group_by(AudioStream.codec)
-        .order_by(func.count(AudioStream.id).desc())
+        select(
+            audio_codec_values.c.value,
+            func.count(distinct(audio_codec_values.c.media_file_id)),
+        )
+        .group_by(audio_codec_values.c.value)
+        .order_by(func.count(distinct(audio_codec_values.c.media_file_id)).desc())
     ).all()
-    audio_language_rows = db.execute(
-        select(AudioStream.language, func.count(AudioStream.id))
-        .group_by(AudioStream.language)
-        .order_by(func.count(AudioStream.id).desc())
-    ).all()
+    audio_language_values = (
+        select(
+            AudioStream.media_file_id.label("media_file_id"),
+            _normalized_language_expr(AudioStream.language).label("value"),
+        )
+        .distinct()
+        .subquery("dashboard_audio_language_values")
+    )
+    audio_language_rows = _count_distinct_normalized_languages(
+        db.execute(select(audio_language_values.c.media_file_id, audio_language_values.c.value)).all(),
+        fallback="und",
+    )
 
-    subtitle_language_rows = merge_language_counts(
-        db.execute(select(SubtitleStream.language, func.count(SubtitleStream.id)).group_by(SubtitleStream.language)).all()
-        + db.execute(select(ExternalSubtitle.language, func.count(ExternalSubtitle.id)).group_by(ExternalSubtitle.language)).all(),
+    subtitle_language_values = union_all(
+        select(
+            SubtitleStream.media_file_id.label("media_file_id"),
+            _normalized_language_expr(SubtitleStream.language).label("value"),
+        ),
+        select(
+            ExternalSubtitle.media_file_id.label("media_file_id"),
+            _normalized_language_expr(ExternalSubtitle.language).label("value"),
+        ),
+    ).subquery("dashboard_subtitle_language_values")
+    subtitle_language_rows = _count_distinct_normalized_languages(
+        db.execute(select(subtitle_language_values.c.media_file_id, subtitle_language_values.c.value)).all(),
         fallback="und",
     )
 

--- a/frontend/src/pages/LibraryDetailPage.test.tsx
+++ b/frontend/src/pages/LibraryDetailPage.test.tsx
@@ -479,6 +479,39 @@ describe("LibraryDetailPage", () => {
     );
   });
 
+  it("passes through und statistic filters unchanged", async () => {
+    const libraryId = 778;
+    vi.spyOn(api, "appSettings").mockResolvedValue({
+      ignore_patterns: [],
+      user_ignore_patterns: [],
+      default_ignore_patterns: [],
+      feature_flags: { show_dolby_vision_profiles: false, show_analyzed_files_csv_export: true },
+    });
+    vi.spyOn(api, "librarySummary").mockResolvedValue(createLibrarySummary(libraryId));
+    vi.spyOn(api, "libraryStatistics").mockResolvedValue(
+      createLibraryStatistics({
+        audio_language_distribution: [{ label: "und", value: 119 }],
+      }),
+    );
+    const libraryFilesSpy = vi.spyOn(api, "libraryFiles").mockResolvedValue(createFilesPage(libraryId));
+
+    renderPage(libraryId);
+
+    expect(await screen.findByText("2 of 2 entries rendered")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /filter analyzed files by audio languages: und/i }));
+
+    await waitFor(() =>
+      expect(libraryFilesSpy).toHaveBeenLastCalledWith(
+        String(libraryId),
+        expect.objectContaining({
+          filters: expect.objectContaining({
+            audio_languages: "und",
+          }),
+        }),
+      ),
+    );
+  });
+
   it("combines file/path and metadata filters in the same request", async () => {
     const libraryId = 505;
     vi.spyOn(api, "appSettings").mockResolvedValue({

--- a/tests/test_library_service.py
+++ b/tests/test_library_service.py
@@ -477,3 +477,170 @@ def test_get_library_statistics_keeps_hdr10_plus_separate_from_hdr10() -> None:
     hdr_distribution = {item.label: item.value for item in statistics.hdr_distribution}
     assert hdr_distribution["HDR10"] == 1
     assert hdr_distribution["HDR10+"] == 1
+
+
+def test_get_library_statistics_counts_undefined_languages_per_file() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as connection:
+        connection.exec_driver_sql("PRAGMA foreign_keys = ON;")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    with session_factory() as db:
+        library = Library(
+            name="Undefined Languages",
+            path="/tmp/undefined-languages",
+            type=LibraryType.series,
+            scan_mode=ScanMode.manual,
+            scan_config={},
+        )
+        db.add(library)
+        db.flush()
+
+        for index in range(119):
+            media_file = MediaFile(
+                library_id=library.id,
+                relative_path=f"episode-{index:03d}.mkv",
+                filename=f"episode-{index:03d}.mkv",
+                extension="mkv",
+                size_bytes=100 + index,
+                mtime=float(index + 1),
+                scan_status=ScanStatus.ready,
+                quality_score=5,
+            )
+            db.add(media_file)
+            db.flush()
+            db.add(AudioStream(media_file_id=media_file.id, stream_index=1, codec="aac", language=None))
+            db.add(AudioStream(media_file_id=media_file.id, stream_index=2, codec="aac", language=""))
+
+        subtitle_undefined = MediaFile(
+            library_id=library.id,
+            relative_path="subtitle-und.mkv",
+            filename="subtitle-und.mkv",
+            extension="mkv",
+            size_bytes=999,
+            mtime=200.0,
+            scan_status=ScanStatus.ready,
+            quality_score=5,
+        )
+        subtitle_german = MediaFile(
+            library_id=library.id,
+            relative_path="subtitle-de.mkv",
+            filename="subtitle-de.mkv",
+            extension="mkv",
+            size_bytes=1000,
+            mtime=201.0,
+            scan_status=ScanStatus.ready,
+            quality_score=5,
+        )
+        db.add_all([subtitle_undefined, subtitle_german])
+        db.flush()
+        db.add_all(
+            [
+                SubtitleStream(
+                    media_file_id=subtitle_undefined.id,
+                    stream_index=2,
+                    codec="subrip",
+                    language=None,
+                    default_flag=False,
+                    forced_flag=False,
+                ),
+                ExternalSubtitle(
+                    media_file_id=subtitle_undefined.id,
+                    path="subtitle-und.und.srt",
+                    language="",
+                    format="srt",
+                ),
+                SubtitleStream(
+                    media_file_id=subtitle_german.id,
+                    stream_index=2,
+                    codec="subrip",
+                    language="ger",
+                    default_flag=False,
+                    forced_flag=False,
+                ),
+            ]
+        )
+        db.commit()
+
+        statistics = get_library_statistics(db, library.id)
+
+    assert statistics is not None
+    audio_languages = {item.label: item.value for item in statistics.audio_language_distribution}
+    subtitle_languages = {item.label: item.value for item in statistics.subtitle_language_distribution}
+    assert audio_languages["und"] == 119
+    assert subtitle_languages["und"] == 1
+    assert subtitle_languages["de"] == 1
+
+
+def test_get_library_statistics_deduplicates_multi_value_panels_per_file() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as connection:
+        connection.exec_driver_sql("PRAGMA foreign_keys = ON;")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    with session_factory() as db:
+        library = Library(
+            name="Deduplicated Stats",
+            path="/tmp/deduplicated-stats",
+            type=LibraryType.series,
+            scan_mode=ScanMode.manual,
+            scan_config={},
+        )
+        db.add(library)
+        db.flush()
+
+        media_file = MediaFile(
+            library_id=library.id,
+            relative_path="episode-01.mkv",
+            filename="episode-01.mkv",
+            extension="mkv",
+            size_bytes=321,
+            mtime=1.0,
+            scan_status=ScanStatus.ready,
+            quality_score=7,
+        )
+        db.add(media_file)
+        db.flush()
+        db.add_all(
+            [
+                AudioStream(media_file_id=media_file.id, stream_index=1, codec="aac", language=None),
+                AudioStream(media_file_id=media_file.id, stream_index=2, codec="aac", language=""),
+                AudioStream(media_file_id=media_file.id, stream_index=3, codec="aac", language="ger"),
+                AudioStream(media_file_id=media_file.id, stream_index=4, codec="aac", language="deu"),
+                SubtitleStream(
+                    media_file_id=media_file.id,
+                    stream_index=5,
+                    codec="subrip",
+                    language=None,
+                    default_flag=False,
+                    forced_flag=False,
+                ),
+                SubtitleStream(
+                    media_file_id=media_file.id,
+                    stream_index=6,
+                    codec="subrip",
+                    language="",
+                    default_flag=False,
+                    forced_flag=False,
+                ),
+                ExternalSubtitle(media_file_id=media_file.id, path="episode-01.und.srt", language=None, format="subrip"),
+                ExternalSubtitle(media_file_id=media_file.id, path="episode-01.ger.srt", language="ger", format="subrip"),
+            ]
+        )
+        db.commit()
+
+        statistics = get_library_statistics(db, library.id)
+
+    assert statistics is not None
+    audio_languages = {item.label: item.value for item in statistics.audio_language_distribution}
+    audio_codecs = {item.label: item.value for item in statistics.audio_codec_distribution}
+    subtitle_languages = {item.label: item.value for item in statistics.subtitle_language_distribution}
+    subtitle_codecs = {item.label: item.value for item in statistics.subtitle_codec_distribution}
+    subtitle_sources = {item.label: item.value for item in statistics.subtitle_source_distribution}
+    assert audio_languages == {"de": 1, "und": 1}
+    assert audio_codecs == {"aac": 1}
+    assert subtitle_languages == {"de": 1, "und": 1}
+    assert subtitle_codecs == {"subrip": 1}
+    assert subtitle_sources == {"external": 1, "internal": 1}

--- a/tests/test_media_service.py
+++ b/tests/test_media_service.py
@@ -18,6 +18,7 @@ from backend.app.models.entities import (
     SubtitleStream,
     VideoStream,
 )
+from backend.app.services.library_service import get_library_statistics
 from backend.app.services.media_search import LibraryFileSearchFilters, SearchValidationError
 from backend.app.services.media_service import generate_library_files_csv_export, list_library_files
 
@@ -881,3 +882,220 @@ def test_generate_library_files_csv_export_reports_no_search_when_unfiltered() -
     assert rows[1][0] == "sample.mkv"
     assert rows[1][3] == ""
     assert rows[1][7] == ""
+
+
+def test_list_library_files_matches_undefined_language_statistics_counts() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    with session_factory() as db:
+        library = Library(
+            name="Undefined Language Search",
+            path="/tmp/undefined-language-search",
+            type=LibraryType.series,
+            scan_mode=ScanMode.manual,
+            scan_config={},
+        )
+        db.add(library)
+        db.flush()
+
+        for index in range(119):
+            media_file = MediaFile(
+                library_id=library.id,
+                relative_path=f"episode-{index:03d}.mkv",
+                filename=f"episode-{index:03d}.mkv",
+                extension="mkv",
+                size_bytes=100 + index,
+                mtime=float(index + 1),
+                scan_status=ScanStatus.ready,
+                quality_score=5,
+            )
+            db.add(media_file)
+            db.flush()
+            db.add(AudioStream(media_file_id=media_file.id, stream_index=1, codec="aac", language=None))
+            db.add(AudioStream(media_file_id=media_file.id, stream_index=2, codec="aac", language=""))
+
+        german_audio = MediaFile(
+            library_id=library.id,
+            relative_path="german-audio.mkv",
+            filename="german-audio.mkv",
+            extension="mkv",
+            size_bytes=999,
+            mtime=150.0,
+            scan_status=ScanStatus.ready,
+            quality_score=5,
+        )
+        subtitle_undefined = MediaFile(
+            library_id=library.id,
+            relative_path="subtitle-und.mkv",
+            filename="subtitle-und.mkv",
+            extension="mkv",
+            size_bytes=1000,
+            mtime=151.0,
+            scan_status=ScanStatus.ready,
+            quality_score=5,
+        )
+        subtitle_english = MediaFile(
+            library_id=library.id,
+            relative_path="subtitle-en.mkv",
+            filename="subtitle-en.mkv",
+            extension="mkv",
+            size_bytes=1001,
+            mtime=152.0,
+            scan_status=ScanStatus.ready,
+            quality_score=5,
+        )
+        db.add_all([german_audio, subtitle_undefined, subtitle_english])
+        db.flush()
+        db.add(AudioStream(media_file_id=german_audio.id, stream_index=1, codec="aac", language="ger"))
+        db.add_all(
+            [
+                SubtitleStream(
+                    media_file_id=subtitle_undefined.id,
+                    stream_index=2,
+                    codec="subrip",
+                    language=None,
+                    default_flag=False,
+                    forced_flag=False,
+                ),
+                ExternalSubtitle(
+                    media_file_id=subtitle_undefined.id,
+                    path="subtitle-und.und.srt",
+                    language="",
+                    format="srt",
+                ),
+                SubtitleStream(
+                    media_file_id=subtitle_english.id,
+                    stream_index=2,
+                    codec="subrip",
+                    language="eng",
+                    default_flag=False,
+                    forced_flag=False,
+                ),
+            ]
+        )
+        db.commit()
+
+        statistics = get_library_statistics(db, library.id)
+        und_audio_page = list_library_files(
+            db,
+            library.id,
+            limit=200,
+            search_filters=LibraryFileSearchFilters(search_audio_languages="und"),
+        )
+        de_audio_page = list_library_files(
+            db,
+            library.id,
+            limit=200,
+            search_filters=LibraryFileSearchFilters(search_audio_languages="de"),
+        )
+        und_subtitle_page = list_library_files(
+            db,
+            library.id,
+            limit=200,
+            search_filters=LibraryFileSearchFilters(search_subtitle_languages="und"),
+        )
+        en_subtitle_page = list_library_files(
+            db,
+            library.id,
+            limit=200,
+            search_filters=LibraryFileSearchFilters(search_subtitle_languages="en"),
+        )
+
+    assert statistics is not None
+    audio_languages = {item.label: item.value for item in statistics.audio_language_distribution}
+    subtitle_languages = {item.label: item.value for item in statistics.subtitle_language_distribution}
+    assert audio_languages["und"] == 119
+    assert und_audio_page.total == 119
+    assert audio_languages["de"] == 1
+    assert de_audio_page.total == 1
+    assert subtitle_languages["und"] == 1
+    assert und_subtitle_page.total == 1
+    assert subtitle_languages["en"] == 1
+    assert en_subtitle_page.total == 1
+
+
+def test_list_library_files_matches_deduplicated_codec_and_source_statistics() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    with session_factory() as db:
+        library = Library(
+            name="Deduplicated Filter Matches",
+            path="/tmp/deduplicated-filter-matches",
+            type=LibraryType.series,
+            scan_mode=ScanMode.manual,
+            scan_config={},
+        )
+        db.add(library)
+        db.flush()
+
+        media_file = MediaFile(
+            library_id=library.id,
+            relative_path="episode-01.mkv",
+            filename="episode-01.mkv",
+            extension="mkv",
+            size_bytes=123,
+            mtime=1.0,
+            scan_status=ScanStatus.ready,
+            quality_score=6,
+        )
+        db.add(media_file)
+        db.flush()
+        db.add_all(
+            [
+                AudioStream(media_file_id=media_file.id, stream_index=1, codec="aac", language="eng"),
+                AudioStream(media_file_id=media_file.id, stream_index=2, codec="aac", language="eng"),
+                SubtitleStream(
+                    media_file_id=media_file.id,
+                    stream_index=3,
+                    codec="subrip",
+                    language="eng",
+                    default_flag=False,
+                    forced_flag=False,
+                ),
+                SubtitleStream(
+                    media_file_id=media_file.id,
+                    stream_index=4,
+                    codec="subrip",
+                    language="eng",
+                    default_flag=False,
+                    forced_flag=False,
+                ),
+                ExternalSubtitle(media_file_id=media_file.id, path="episode-01.en.srt", language="eng", format="subrip"),
+            ]
+        )
+        db.commit()
+
+        statistics = get_library_statistics(db, library.id)
+        audio_codec_page = list_library_files(
+            db,
+            library.id,
+            limit=50,
+            search_filters=LibraryFileSearchFilters(search_audio_codecs="aac"),
+        )
+        subtitle_codec_page = list_library_files(
+            db,
+            library.id,
+            limit=50,
+            search_filters=LibraryFileSearchFilters(search_subtitle_codecs="subrip"),
+        )
+        subtitle_source_page = list_library_files(
+            db,
+            library.id,
+            limit=50,
+            search_filters=LibraryFileSearchFilters(search_subtitle_sources="internal"),
+        )
+
+    assert statistics is not None
+    audio_codecs = {item.label: item.value for item in statistics.audio_codec_distribution}
+    subtitle_codecs = {item.label: item.value for item in statistics.subtitle_codec_distribution}
+    subtitle_sources = {item.label: item.value for item in statistics.subtitle_source_distribution}
+    assert audio_codecs["aac"] == 1
+    assert subtitle_codecs["subrip"] == 1
+    assert subtitle_sources["internal"] == 1
+    assert audio_codec_page.total == 1
+    assert subtitle_codec_page.total == 1
+    assert subtitle_source_page.total == 1

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -106,8 +106,8 @@ def test_dashboard_merges_common_audio_language_aliases() -> None:
         dashboard = build_dashboard(db)
 
     audio_languages = {item.label: item.value for item in dashboard.audio_language_distribution}
-    assert audio_languages["de"] == 3
-    assert audio_languages["en"] == 2
+    assert audio_languages["de"] == 1
+    assert audio_languages["en"] == 1
     assert "deu" not in audio_languages
     assert "ger" not in audio_languages
     assert "eng" not in audio_languages


### PR DESCRIPTION
## Summary

fix the counting of languages of audio/subtitle-tracks. earlier the tracks/streams were counted, now the files including those languages are counted. Should fix counting mismatch now.

## Changes

- Adjusted file counting logic to count files instead of streams

## Testing

- Tested with dev-Library

## Checklist

- [x] I tested the change locally.
- [x] I updated docs if behavior/config changed.
- [x] I kept the scope focused (single concern).
- [x] I did not include secrets or local machine artifacts.

