### PR TITLE
fix: updateOrderedQualityBoundary ranks was undefined for resolution

### DIFF
--- a/frontend/src/pages/LibrariesPage.tsx
+++ b/frontend/src/pages/LibrariesPage.tsx
@@ -1458,7 +1458,7 @@ export function LibrariesPage() {
   ) {
     updateLibraryQualityProfile(libraryId, (current) => {
       const category = current[key];
-      const ranks = QUALITY_OPTION_RANKS[key];
+      const ranks = key === "resolution" ? resolutionCategoryRanks(resolutionOptions) : QUALITY_OPTION_RANKS[key];
       const nextCategory = { ...category, [boundary]: value };
       const minimumValue = String(boundary === "minimum" ? value : nextCategory.minimum);
       const idealValue = String(boundary === "ideal" ? value : nextCategory.ideal);


### PR DESCRIPTION
## Summary

The variable `ranks` in the function `updateOrderedQualityBoundary` was being set as undefined when the key is `resolution` due to it not existing in `QUALITY_OPTION_RANKS`. Since the method to populate the variable `ranks` in the function `renderQualityOrdinalRow` works, i switched to it.

May fix #71.

## Changes

- Fixed `ranks` assignment in `updateOrderedQualityBoundary`

## Testing

- Tried to change the any resolution for a library from the UI

## Checklist

- [x] I tested the change locally.
- [x] I updated docs if behavior/config changed.
- [x] I kept the scope focused (single concern).
- [x] I did not include secrets or local machine artifacts.
