### PR TITLE
Fix mutable resolution category IDs and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - allow adding new resolution categories from the settings UI without tripping the backend's immutable-id validation ([#71](https://github.com/frederikemmer/MediaLyze/issues/71))
+- fix resolution quality-boundary updates in the library quality settings when `minimum` / `ideal` values are changed ([#72](https://github.com/frederikemmer/MediaLyze/pull/72)) - by [@eivarin](https://github.com/eivarin)
 
 ## v0.2.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## vUnreleased
 
+### 🐛 Bug fixes
+- allow adding new resolution categories from the settings UI without tripping the backend's immutable-id validation ([#71](https://github.com/frederikemmer/MediaLyze/issues/71))
+
 ## v0.2.5
 
 >2026-03-24

--- a/frontend/src/pages/LibrariesPage.test.tsx
+++ b/frontend/src/pages/LibrariesPage.test.tsx
@@ -364,6 +364,43 @@ describe("LibrariesPage ignore patterns", () => {
     );
   });
 
+  it("adds new resolution categories without persisting a client-generated id", async () => {
+    const updateSpy = vi.spyOn(api, "updateAppSettings").mockResolvedValue(
+      createAppSettings({
+        resolution_categories: [
+          { id: "8k", label: "8k", min_width: 7680, min_height: 4320 },
+          { id: "4k", label: "4k", min_width: 3840, min_height: 2160 },
+          { id: "1440p", label: "1440p", min_width: 2560, min_height: 1440 },
+          { id: "1080p", label: "1080p", min_width: 1920, min_height: 1080 },
+          { id: "720p", label: "720p", min_width: 1280, min_height: 720 },
+          { id: "480p", label: "480p", min_width: 854, min_height: 480 },
+          { id: "sd", label: "sd", min_width: 0, min_height: 0 },
+        ],
+      }),
+    );
+
+    renderPage();
+
+    fireEvent.change(await screen.findByPlaceholderText("New category"), { target: { value: "480p" } });
+    fireEvent.change(screen.getByLabelText("Min width", { selector: "#resolution-category-new-width" }), {
+      target: { value: "854" },
+    });
+    fireEvent.change(screen.getByLabelText("Min height", { selector: "#resolution-category-new-height" }), {
+      target: { value: "480" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add resolution category" }));
+
+    await waitFor(() =>
+      expect(updateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resolution_categories: expect.arrayContaining([
+            expect.objectContaining({ id: "", label: "480p", min_width: 854, min_height: 480 }),
+          ]),
+        }),
+      ),
+    );
+  });
+
   it("clamps visual density maximum when the ideal is raised above it", async () => {
     const library = createLibrarySummary();
     vi.spyOn(api, "libraries").mockResolvedValue([library]);

--- a/frontend/src/pages/LibrariesPage.tsx
+++ b/frontend/src/pages/LibrariesPage.tsx
@@ -136,7 +136,12 @@ function cloneResolutionCategoryDrafts(categories: ResolutionCategory[]): Resolu
 }
 
 function resolutionCategoriesFromDrafts(drafts: ResolutionCategoryDraft[]): ResolutionCategory[] {
-  return normalizeResolutionCategories(drafts.map(({ persisted, ...category }) => category));
+  return normalizeResolutionCategories(
+    drafts.map(({ persisted, ...category }) => ({
+      ...category,
+      id: persisted ? category.id : "",
+    })),
+  );
 }
 
 function createResolutionCategoryId(label: string, drafts: ResolutionCategoryDraft[]): string {
@@ -1868,9 +1873,7 @@ export function LibrariesPage() {
     );
   }
 
-  const normalizedResolutionDrafts = normalizeResolutionCategories(
-    resolutionCategoryDrafts.map(({ persisted, ...category }) => category),
-  );
+  const normalizedResolutionDrafts = resolutionCategoriesFromDrafts(resolutionCategoryDrafts);
   const resolutionCategoryChangeKind = resolutionCategoryChangeSummary(
     persistedResolutionCategories.current,
     normalizedResolutionDrafts,


### PR DESCRIPTION
## Summary

Resolution category IDs are now mutable, allowing the addition of new categories from the settings UI without triggering immutable ID validation on the backend.

## Changes

- Updated logic to handle mutable resolution category IDs

## Testing

- Added tests to ensure new resolution categories can be added without persisting a client-generated ID

## Checklist

- [x] I tested the change locally.
- [x] I updated docs if behavior/config changed.
- [x] I kept the scope focused (single concern).
- [x] I did not include secrets or local machine artifacts.