### PR TITLE
Fix handling of Windows UNC network share paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### 🐛 Bug fixes
 - allow adding new resolution categories from the settings UI without tripping the backend's immutable-id validation ([#71](https://github.com/frederikemmer/MediaLyze/issues/71))
 - fix resolution quality-boundary updates in the library quality settings when `minimum` / `ideal` values are changed ([#72](https://github.com/frederikemmer/MediaLyze/pull/72)) - by [@eivarin](https://github.com/eivarin)
+- keep Windows UNC network-share paths in their normal form for `ffprobe` so desktop scans analyze files on network shares instead of only listing them
 
 ## v0.2.5
 

--- a/backend/app/services/ffprobe_parser.py
+++ b/backend/app/services/ffprobe_parser.py
@@ -128,7 +128,10 @@ def _ffprobe_input_path(file_path: Path) -> str:
     if path_value.startswith("\\\\?\\"):
         return path_value
     if path_value.startswith("\\\\"):
-        return f"\\\\?\\UNC\\{path_value.lstrip('\\')}"
+        # Keep UNC paths in their canonical form for ffprobe. Discovery works with
+        # network shares directly, but the extended-length UNC prefix can prevent
+        # ffprobe from opening the same file on Windows desktop scans.
+        return path_value
     if len(path_value) >= 2 and path_value[1] == ":":
         return f"\\\\?\\{path_value}"
     return path_value

--- a/tests/test_ffprobe_parser.py
+++ b/tests/test_ffprobe_parser.py
@@ -1,6 +1,8 @@
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 
+import backend.app.services.ffprobe_parser as ffprobe_parser
 from backend.app.services.ffprobe_parser import _ffprobe_error_message, _ffprobe_input_path, normalize_ffprobe_payload
 
 
@@ -158,3 +160,15 @@ def test_ffprobe_input_path_preserves_non_windows_paths(tmp_path: Path) -> None:
     file_path = tmp_path / "movie.mkv"
 
     assert _ffprobe_input_path(file_path) == str(file_path)
+
+
+def test_ffprobe_input_path_preserves_windows_unc_paths(monkeypatch) -> None:
+    monkeypatch.setattr(ffprobe_parser, "os", SimpleNamespace(name="nt"))
+
+    assert _ffprobe_input_path(Path(r"\\server\share\movies\movie.mkv")) == r"\\server\share\movies\movie.mkv"
+
+
+def test_ffprobe_input_path_adds_extended_prefix_for_windows_drive_paths(monkeypatch) -> None:
+    monkeypatch.setattr(ffprobe_parser, "os", SimpleNamespace(name="nt"))
+
+    assert _ffprobe_input_path(Path(r"C:\media\movie.mkv")) == r"\\?\C:\media\movie.mkv"


### PR DESCRIPTION
## Summary

Keep Windows UNC network-share paths in their normal form for `ffprobe`, allowing desktop scans to analyze files on network shares instead of only listing them.

## Changes

- Adjusted the handling of UNC paths in the `_ffprobe_input_path` function to preserve their canonical form

## Testing

- Added tests to ensure that UNC paths are preserved and that extended prefixes are added for Windows drive paths

## Checklist

- [x] I tested the change locally.
- [x] I updated docs if behavior/config changed.
- [x] I kept the scope focused (single concern).
- [x] I did not include secrets or local machine artifacts.

