### PR TITLE
Add missing metrics to historic data graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## vUnreleased
 
+## v0.8.2
+
+>2026-04-20
+
+### 🐛 Bug fixes
+
+- backfill legacy library-history snapshots with total size, total duration, file-size summaries, and resolution megapixel summaries so the newer history metrics render for older stored data
+
 ## v0.8.1
 
 >2026-04-20

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY frontend/ ./
 RUN npm run build
 
 FROM python:3.12-alpine AS runtime
-ARG APP_VERSION=0.8.1
+ARG APP_VERSION=0.8.2
 
 LABEL name="MediaLyze"
 LABEL org.opencontainers.image.source="https://github.com/frederikemmer/MediaLyze"

--- a/backend/app/services/library_history_service.py
+++ b/backend/app/services/library_history_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections import OrderedDict
 
 from sqlalchemy import select
@@ -18,6 +19,19 @@ from backend.app.schemas.media import NumericDistribution, NumericDistributionBi
 from backend.app.services.app_settings import get_app_settings
 from backend.app.services.stats_cache import stats_cache
 from backend.app.utils.time import utc_now
+
+
+STANDARD_RESOLUTION_MEGAPIXELS: dict[str, float] = {
+    "8k": (7680 * 4320) / 1_000_000,
+    "4k": (3840 * 2160) / 1_000_000,
+    "2160p": (3840 * 2160) / 1_000_000,
+    "1440p": (2560 * 1440) / 1_000_000,
+    "1080p": (1920 * 1080) / 1_000_000,
+    "720p": (1280 * 720) / 1_000_000,
+    "576p": (720 * 576) / 1_000_000,
+    "480p": (720 * 480) / 1_000_000,
+    "sd": (720 * 480) / 1_000_000,
+}
 
 
 def _coerce_float(value) -> float | None:
@@ -64,6 +78,30 @@ def _coerce_totals(value) -> dict[str, int | float]:
     return totals
 
 
+def _coerce_legacy_totals(snapshot: dict) -> dict[str, int | float]:
+    totals: dict[str, int | float] = {}
+    for key in ("file_count", "ready_files", "pending_files", "total_size_bytes"):
+        value = _coerce_int(snapshot.get(key))
+        if value is not None:
+            totals[key] = value
+    total_duration_seconds = _coerce_float(snapshot.get("total_duration_seconds"))
+    if total_duration_seconds is not None:
+        totals["total_duration_seconds"] = total_duration_seconds
+    return totals
+
+
+def _has_enriched_legacy_totals(totals: dict[str, int | float]) -> bool:
+    return any(
+        key in totals
+        for key in (
+            "ready_files",
+            "pending_files",
+            "total_size_bytes",
+            "total_duration_seconds",
+        )
+    )
+
+
 def _coerce_numeric_summary(value) -> LibraryHistoryNumericSummaryRead | None:
     if not isinstance(value, dict):
         return None
@@ -103,6 +141,68 @@ def _legacy_summary(value: float | None, weight: int) -> LibraryHistoryNumericSu
         average=value,
         minimum=value,
         maximum=value,
+    )
+
+
+def _legacy_size_summary(
+    totals: dict[str, int | float],
+    total_files: int,
+) -> LibraryHistoryNumericSummaryRead | None:
+    total_size_bytes = _coerce_float(totals.get("total_size_bytes"))
+    if total_size_bytes is None:
+        return None
+    count = _coerce_int(totals.get("file_count")) or total_files
+    if count <= 0:
+        return None
+    return LibraryHistoryNumericSummaryRead(
+        count=count,
+        sum=total_size_bytes,
+        average=total_size_bytes / count,
+        minimum=None,
+        maximum=None,
+    )
+
+
+def _resolution_label_megapixels(value: str) -> float | None:
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized in STANDARD_RESOLUTION_MEGAPIXELS:
+        return STANDARD_RESOLUTION_MEGAPIXELS[normalized]
+    match = re.search(r"(?P<height>\d{3,4})p", normalized)
+    if match is None:
+        return None
+    height = int(match.group("height"))
+    if height <= 0:
+        return None
+    width = round(height * 16 / 9)
+    return (width * height) / 1_000_000
+
+
+def _legacy_resolution_mp_summary(
+    resolution_counts: dict[str, int],
+    resolution_categories: OrderedDict[str, str],
+) -> LibraryHistoryNumericSummaryRead | None:
+    weighted_sum = 0.0
+    count = 0
+    for category_id, category_count in resolution_counts.items():
+        if category_count <= 0:
+            continue
+        megapixels = _resolution_label_megapixels(category_id)
+        if megapixels is None:
+            megapixels = _resolution_label_megapixels(resolution_categories.get(category_id, ""))
+        if megapixels is None:
+            continue
+        weighted_sum += megapixels * category_count
+        count += category_count
+    if count <= 0:
+        return None
+    return LibraryHistoryNumericSummaryRead(
+        count=count,
+        sum=weighted_sum,
+        average=weighted_sum / count,
+        minimum=None,
+        maximum=None,
     )
 
 
@@ -169,7 +269,14 @@ def _parse_history_metrics(
 ) -> LibraryHistoryTrendMetricsRead | None:
     raw_metrics = snapshot.get("trend_metrics")
     if not isinstance(raw_metrics, dict):
-        return None
+        legacy_totals = _coerce_legacy_totals(snapshot)
+        if not _has_enriched_legacy_totals(legacy_totals):
+            return None
+        raw_metrics = {
+            "total_files": legacy_totals.get("ready_files", legacy_totals.get("file_count", 0)),
+            "resolution_counts": {},
+            "totals": legacy_totals,
+        }
 
     raw_resolution_counts = raw_metrics.get("resolution_counts")
     resolution_counts: dict[str, int] = {}
@@ -192,6 +299,18 @@ def _parse_history_metrics(
     average_duration_seconds = _coerce_float(raw_metrics.get("average_duration_seconds"))
     average_quality_score = _coerce_float(raw_metrics.get("average_quality_score"))
 
+    totals = _coerce_totals(raw_metrics.get("totals"))
+    for total_key, total_value in _coerce_legacy_totals(snapshot).items():
+        totals.setdefault(total_key, total_value)
+    if "file_count" not in totals and total_files > 0:
+        totals["file_count"] = total_files
+    if (
+        "total_duration_seconds" not in totals
+        and average_duration_seconds is not None
+        and total_files > 0
+    ):
+        totals["total_duration_seconds"] = average_duration_seconds * total_files
+
     numeric_summaries = _coerce_numeric_summaries(raw_metrics.get("numeric_summaries"))
     for metric_id, average_value in (
         ("bitrate", average_bitrate),
@@ -203,6 +322,17 @@ def _parse_history_metrics(
             legacy_summary = _legacy_summary(average_value, total_files)
             if legacy_summary is not None:
                 numeric_summaries[metric_id] = legacy_summary
+    if "size" not in numeric_summaries:
+        legacy_size_summary = _legacy_size_summary(totals, total_files)
+        if legacy_size_summary is not None:
+            numeric_summaries["size"] = legacy_size_summary
+    if "resolution_mp" not in numeric_summaries:
+        legacy_resolution_summary = _legacy_resolution_mp_summary(
+            resolution_counts,
+            resolution_categories,
+        )
+        if legacy_resolution_summary is not None:
+            numeric_summaries["resolution_mp"] = legacy_resolution_summary
 
     category_counts = _coerce_category_counts(raw_metrics.get("category_counts"))
     category_counts.setdefault("resolution", dict(resolution_counts))
@@ -215,7 +345,7 @@ def _parse_history_metrics(
         average_audio_bitrate=average_audio_bitrate,
         average_duration_seconds=average_duration_seconds,
         average_quality_score=average_quality_score,
-        totals=_coerce_totals(raw_metrics.get("totals")),
+        totals=totals,
         numeric_summaries=numeric_summaries,
         category_counts=category_counts,
         numeric_distributions=_coerce_numeric_distributions(raw_metrics.get("numeric_distributions")),

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medialyze-desktop",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medialyze-desktop",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "devDependencies": {
         "electron": "^39.8.5",
         "electron-builder": "^26.0.12",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medialyze-desktop",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "description": "Desktop packaging for the MediaLyze local media analysis app.",
   "author": "Frederik Emmer",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medialyze-frontend",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medialyze-frontend",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@tanstack/react-virtual": "^3.13.21",
         "echarts": "^6.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medialyze-frontend",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "medialyze"
-version = "0.8.1"
+version = "0.8.2"
 description = "Self-hosted media library analyzer for technical video metadata."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_history_services.py
+++ b/tests/test_history_services.py
@@ -204,6 +204,9 @@ def test_get_dashboard_history_aggregates_visible_libraries() -> None:
                     library_id=visible_library.id,
                     snapshot_day="2026-03-24",
                     snapshot={
+                        "file_count": 2,
+                        "total_size_bytes": 3_000,
+                        "total_duration_seconds": 10_800,
                         "trend_metrics": {
                             "total_files": 2,
                             "resolution_counts": {"4k": 2},
@@ -218,6 +221,9 @@ def test_get_dashboard_history_aggregates_visible_libraries() -> None:
                     library_id=visible_library.id,
                     snapshot_day="2026-03-25",
                     snapshot={
+                        "file_count": 3,
+                        "total_size_bytes": 6_000,
+                        "total_duration_seconds": 18_000,
                         "trend_metrics": {
                             "total_files": 3,
                             "resolution_counts": {"4k": 1, "1080p": 2},
@@ -255,6 +261,10 @@ def test_get_dashboard_history_aggregates_visible_libraries() -> None:
     assert payload.points[0].trend_metrics.total_files == 2
     assert payload.points[0].trend_metrics.resolution_counts == {"4k": 2}
     assert payload.points[0].trend_metrics.average_bitrate == 8_000_000.0
+    assert payload.points[0].trend_metrics.totals["total_size_bytes"] == 3_000
+    assert payload.points[0].trend_metrics.totals["total_duration_seconds"] == 10_800.0
+    assert payload.points[0].trend_metrics.numeric_summaries["size"].average == 1_500.0
+    assert payload.points[0].trend_metrics.numeric_summaries["resolution_mp"].average == 8.2944
 
 
 def test_build_library_history_snapshot_includes_trend_metrics() -> None:
@@ -401,7 +411,7 @@ def test_build_library_history_snapshot_returns_null_for_null_only_average_colum
     assert snapshot["trend_metrics"]["average_quality_score"] == 5.0
 
 
-def test_get_library_history_skips_legacy_rows_and_preserves_unknown_resolution_categories() -> None:
+def test_get_library_history_enriches_legacy_rows_and_preserves_unknown_resolution_categories() -> None:
     session_factory = _session_factory()
     settings = Settings()
 
@@ -432,13 +442,22 @@ def test_get_library_history_skips_legacy_rows_and_preserves_unknown_resolution_
                     library_id=library.id,
                     snapshot_day="2026-03-22",
                     captured_at=datetime(2026, 3, 22, 9, 0, tzinfo=UTC),
-                    snapshot={"file_count": 1},
+                    snapshot={
+                        "file_count": 1,
+                        "ready_files": 1,
+                        "pending_files": 0,
+                        "total_size_bytes": 1_500_000_000,
+                        "total_duration_seconds": 5_400,
+                    },
                 ),
                 LibraryHistory(
                     library_id=library.id,
                     snapshot_day="2026-03-23",
                     captured_at=datetime(2026, 3, 23, 9, 0, tzinfo=UTC),
                     snapshot={
+                        "file_count": 10,
+                        "total_size_bytes": 15_000_000_000,
+                        "total_duration_seconds": 54_000,
                         "trend_metrics": {
                             "total_files": 10,
                             "resolution_counts": {"4k": 4, "legacy_hd": 6},
@@ -471,10 +490,20 @@ def test_get_library_history_skips_legacy_rows_and_preserves_unknown_resolution_
         payload = get_library_history(db, library.id)
 
     assert payload is not None
-    assert payload.oldest_snapshot_day == "2026-03-23"
+    assert payload.oldest_snapshot_day == "2026-03-22"
     assert payload.newest_snapshot_day == "2026-03-24"
-    assert [point.snapshot_day for point in payload.points] == ["2026-03-23", "2026-03-24"]
-    assert payload.points[0].trend_metrics.resolution_counts["legacy_hd"] == 6
+    assert [point.snapshot_day for point in payload.points] == [
+        "2026-03-22",
+        "2026-03-23",
+        "2026-03-24",
+    ]
+    assert payload.points[0].trend_metrics.totals["total_size_bytes"] == 1_500_000_000
+    assert payload.points[0].trend_metrics.totals["total_duration_seconds"] == 5_400.0
+    assert payload.points[0].trend_metrics.numeric_summaries["size"].average == 1_500_000_000.0
+    assert payload.points[1].trend_metrics.resolution_counts["legacy_hd"] == 6
+    assert payload.points[1].trend_metrics.totals["total_duration_seconds"] == 54_000.0
+    assert payload.points[1].trend_metrics.numeric_summaries["resolution_mp"].average == 8.2944
+    assert payload.points[2].trend_metrics.numeric_summaries["resolution_mp"].average == 2.0736
     assert [item.model_dump() for item in payload.resolution_categories] == [
         {"id": "4k", "label": "Ultra HD"},
         {"id": "1080p", "label": "Full HD"},

--- a/uv.lock
+++ b/uv.lock
@@ -224,7 +224,7 @@ wheels = [
 
 [[package]]
 name = "medialyze"
-version = "0.8.1"
+version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },


### PR DESCRIPTION
## Summary

The update introduces missing metrics for legacy library-history snapshots, enhancing the historic data graph. This change ensures that older stored data can render newer history metrics effectively.

## Changes

- Updated version to 0.8.2 across relevant files
- Backfilled legacy library-history snapshots with total size, total duration, file-size summaries, and resolution megapixel summaries

## Testing

- Verified that the new metrics render correctly for both legacy and current data

## Checklist

- [x] I tested the change locally.
- [x] I updated docs if behavior/config changed.
- [x] I kept the scope focused (single concern).
- [x] I did not include secrets or local machine artifacts.

