### PR TITLE
Add stable desktop release asset names

### DIFF
--- a/.github/workflows/build-desktop-dev.yaml
+++ b/.github/workflows/build-desktop-dev.yaml
@@ -83,23 +83,45 @@ jobs:
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
 
+      - name: Verify desktop artifact name
+        shell: bash
+        run: |
+          case "${{ matrix.os }}" in
+            ubuntu-latest)
+              expected="dist/desktop-app/MediaLyze.AppImage"
+              ;;
+            macos-latest)
+              expected="dist/desktop-app/MediaLyze-arm64.dmg"
+              ;;
+            windows-latest)
+              expected="dist/desktop-app/MediaLyze.Setup.exe"
+              ;;
+          esac
+
+          if [[ ! -f "$expected" ]]; then
+            echo "Expected desktop artifact not found: $expected" >&2
+            echo "Available files:" >&2
+            ls -la dist/desktop-app >&2
+            exit 1
+          fi
+
       - name: Upload Linux desktop artifact
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
           name: medialyze-desktop-linux
-          path: dist/desktop-app/*.AppImage
+          path: dist/desktop-app/MediaLyze.AppImage
 
       - name: Upload macOS desktop artifact
         if: matrix.os == 'macos-latest'
         uses: actions/upload-artifact@v4
         with:
           name: medialyze-desktop-macos
-          path: dist/desktop-app/*.dmg
+          path: dist/desktop-app/MediaLyze-arm64.dmg
 
       - name: Upload Windows desktop artifact
         if: matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v4
         with:
           name: medialyze-desktop-windows
-          path: dist/desktop-app/*.exe
+          path: dist/desktop-app/MediaLyze.Setup.exe

--- a/.github/workflows/build-desktop.yaml
+++ b/.github/workflows/build-desktop.yaml
@@ -129,28 +129,43 @@ jobs:
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
 
+      - name: Verify desktop artifact name
+        shell: bash
+        run: |
+          case "${{ matrix.os }}" in
+            ubuntu-latest)
+              expected="dist/desktop-app/MediaLyze.AppImage"
+              ;;
+            macos-latest)
+              expected="dist/desktop-app/MediaLyze-arm64.dmg"
+              ;;
+            windows-latest)
+              expected="dist/desktop-app/MediaLyze.Setup.exe"
+              ;;
+          esac
+
+          if [[ ! -f "$expected" ]]; then
+            echo "Expected desktop artifact not found: $expected" >&2
+            echo "Available files:" >&2
+            ls -la dist/desktop-app >&2
+            exit 1
+          fi
+
       - name: Upload desktop asset to GitHub release
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          shopt -s nullglob
-          assets=()
           case "${{ matrix.os }}" in
             ubuntu-latest)
-              assets=(dist/desktop-app/*.AppImage)
+              asset="dist/desktop-app/MediaLyze.AppImage"
               ;;
             macos-latest)
-              assets=(dist/desktop-app/*.dmg)
+              asset="dist/desktop-app/MediaLyze-arm64.dmg"
               ;;
             windows-latest)
-              assets=(dist/desktop-app/*.exe)
+              asset="dist/desktop-app/MediaLyze.Setup.exe"
               ;;
           esac
 
-          if [[ ${#assets[@]} -eq 0 ]]; then
-            echo "No desktop artifacts found for ${{ matrix.os }}" >&2
-            exit 1
-          fi
-
-          gh release upload "${{ env.RELEASE_TAG }}" "${assets[@]}" --clobber
+          gh release upload "${{ env.RELEASE_TAG }}" "$asset" --clobber

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -884,6 +884,7 @@ Current release behavior:
 * official images are published to GHCR
 * the official release workflow creates the matching `vX.Y.Z` tag and GitHub release from that `main` commit
 * the desktop-release workflow can also be dispatched manually for an existing release tag, optionally building from a different git ref while still uploading assets to the original release tag
+* desktop release assets now use stable versionless filenames per platform so documentation can link through `releases/latest/download/...` to the newest published desktop installers
 * GitHub releases use extracted release notes based on repository metadata
 * upcoming release notes should be accumulated under `CHANGELOG.md` in `vUnreleased`
 * when a new version is released, the relevant `vUnreleased` entries should be moved into the new version section instead of being rewritten from scratch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## vUnreleased
 
+### ✨ New
+
+- add stable desktop release asset names so README download links can point at `releases/latest/download/...` and always fetch the newest published desktop build
+
 ## v0.9.0
 
 >2026-04-25

--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@
   MediaLyze focuses (for now) on just analysis, not playback, scraping, or file modification, READ ONLY on your files!
 </p>
 
+## Desktop Downloads
+
+| Platform | Download |
+| --- | --- |
+| macOS Apple Silicon | [Download](https://github.com/frederikemmer/MediaLyze/releases/latest/download/MediaLyze-arm64.dmg) |
+| Linux | [Download](https://github.com/frederikemmer/MediaLyze/releases/latest/download/MediaLyze.AppImage) |
+| Windows | [Download](https://github.com/frederikemmer/MediaLyze/releases/latest/download/MediaLyze.Setup.exe) |
+| All release assets | [Open latest release](https://github.com/frederikemmer/MediaLyze/releases/latest) |
+
 ![MediaLyze dashboard](docs/images/Dashboard.png)
 
 ## Why MediaLyze

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -48,6 +48,7 @@
       "target": [
         "dmg"
       ],
+      "artifactName": "${productName}-arm64.${ext}",
       "icon": "medialyze.icns",
       "category": "public.app-category.video"
     },
@@ -55,6 +56,7 @@
       "target": [
         "AppImage"
       ],
+      "artifactName": "${productName}.${ext}",
       "icon": "icon512.png",
       "category": "AudioVideo"
     },
@@ -62,6 +64,7 @@
       "target": [
         "nsis"
       ],
+      "artifactName": "${productName}.Setup.${ext}",
       "icon": "medialyze.ico"
     }
   }

--- a/desktop/package.test.cjs
+++ b/desktop/package.test.cjs
@@ -12,6 +12,24 @@ test("desktop packaged app includes all runtime CommonJS entry files", () => {
   );
 });
 
+test("desktop packaging uses stable release artifact names", () => {
+  assert.equal(
+    packageJson.build?.mac?.artifactName,
+    "${productName}-arm64.${ext}",
+    "Expected macOS desktop artifact name to stay stable"
+  );
+  assert.equal(
+    packageJson.build?.linux?.artifactName,
+    "${productName}.${ext}",
+    "Expected Linux desktop artifact name to stay stable"
+  );
+  assert.equal(
+    packageJson.build?.win?.artifactName,
+    "${productName}.Setup.${ext}",
+    "Expected Windows desktop artifact name to stay stable"
+  );
+});
+
 function expectEntries(actualEntries, requiredEntries) {
   for (const entry of requiredEntries) {
     assert.equal(

--- a/docs/build_desktop.md
+++ b/docs/build_desktop.md
@@ -58,7 +58,7 @@ npm --prefix desktop run dist
 
 Additional output:
 
-- installer: `dist/desktop-app/MediaLyze-*.dmg`
+- installer: `dist/desktop-app/MediaLyze-arm64.dmg`
 
 ## Windows
 
@@ -92,7 +92,7 @@ npm run dist
 
 Output:
 
-- installer: `dist/desktop-app/MediaLyze Setup *.exe`
+- installer: `dist/desktop-app/MediaLyze.Setup.exe`
 
 If you want the unpacked desktop app directory instead of the installer:
 


### PR DESCRIPTION
## Summary

Updated desktop release asset names to be stable and versionless, allowing documentation links to always point to the latest published builds.

## Changes

- Implemented stable artifact names for macOS, Linux, and Windows desktop releases
- Added verification for expected artifact names in the CI workflow
- Updated documentation to reflect new download links

## Testing

- Verified that the correct artifact names are generated and uploaded during the release process

## Checklist

- [x] I tested the change locally.
- [x] I updated docs if behavior/config changed.
- [x] I kept the scope focused (single concern).
- [x] I did not include secrets or local machine artifacts.

