### PR TITLE
Bundle Linux ffprobe dependencies and enhance handling

### DIFF
--- a/.github/workflows/build-desktop-dev.yaml
+++ b/.github/workflows/build-desktop-dev.yaml
@@ -105,6 +105,42 @@ jobs:
             exit 1
           fi
 
+      - name: Verify Linux AppImage ffprobe bundle
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          set -euo pipefail
+          appimage="dist/desktop-app/MediaLyze.AppImage"
+          chmod +x "$appimage"
+          rm -rf squashfs-root
+          "$appimage" --appimage-extract >/dev/null
+
+          ffprobe_dir="squashfs-root/resources/backend/ffprobe"
+          ffprobe_bin="$ffprobe_dir/ffprobe"
+          ffprobe_lib="$ffprobe_dir/lib"
+
+          if [[ ! -x "$ffprobe_bin" ]]; then
+            echo "Bundled ffprobe executable is missing from AppImage: $ffprobe_bin" >&2
+            exit 1
+          fi
+
+          if [[ ! -d "$ffprobe_lib" ]]; then
+            echo "Bundled ffprobe library directory is missing from AppImage: $ffprobe_lib" >&2
+            exit 1
+          fi
+
+          if ! find "$ffprobe_lib" -maxdepth 1 -type f -name 'libavdevice.so*' | grep -q .; then
+            echo "Bundled ffprobe library directory does not contain libavdevice.so*" >&2
+            find "$ffprobe_lib" -maxdepth 1 -type f -printf '%f\n' >&2
+            exit 1
+          fi
+
+          if LD_LIBRARY_PATH="$PWD/$ffprobe_lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ldd "$ffprobe_bin" | grep -q 'not found'; then
+            echo "Bundled ffprobe still has unresolved shared-library dependencies." >&2
+            LD_LIBRARY_PATH="$PWD/$ffprobe_lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ldd "$ffprobe_bin" >&2
+            exit 1
+          fi
+
       - name: Upload Linux desktop artifact
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-desktop.yaml
+++ b/.github/workflows/build-desktop.yaml
@@ -151,6 +151,42 @@ jobs:
             exit 1
           fi
 
+      - name: Verify Linux AppImage ffprobe bundle
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          set -euo pipefail
+          appimage="dist/desktop-app/MediaLyze.AppImage"
+          chmod +x "$appimage"
+          rm -rf squashfs-root
+          "$appimage" --appimage-extract >/dev/null
+
+          ffprobe_dir="squashfs-root/resources/backend/ffprobe"
+          ffprobe_bin="$ffprobe_dir/ffprobe"
+          ffprobe_lib="$ffprobe_dir/lib"
+
+          if [[ ! -x "$ffprobe_bin" ]]; then
+            echo "Bundled ffprobe executable is missing from AppImage: $ffprobe_bin" >&2
+            exit 1
+          fi
+
+          if [[ ! -d "$ffprobe_lib" ]]; then
+            echo "Bundled ffprobe library directory is missing from AppImage: $ffprobe_lib" >&2
+            exit 1
+          fi
+
+          if ! find "$ffprobe_lib" -maxdepth 1 -type f -name 'libavdevice.so*' | grep -q .; then
+            echo "Bundled ffprobe library directory does not contain libavdevice.so*" >&2
+            find "$ffprobe_lib" -maxdepth 1 -type f -printf '%f\n' >&2
+            exit 1
+          fi
+
+          if LD_LIBRARY_PATH="$PWD/$ffprobe_lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ldd "$ffprobe_bin" | grep -q 'not found'; then
+            echo "Bundled ffprobe still has unresolved shared-library dependencies." >&2
+            LD_LIBRARY_PATH="$PWD/$ffprobe_lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ldd "$ffprobe_bin" >&2
+            exit 1
+          fi
+
       - name: Upload desktop asset to GitHub release
         shell: bash
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## vUnreleased
 
+## v0.10.1
+
+>2026-05-04
+
+- bundle Linux desktop `ffprobe` shared-library dependencies into AppImage builds and load them at runtime so scans no longer fail when the host distribution has incompatible FFmpeg library versions ([#127](https://github.com/frederikemmer/MediaLyze/issues/127))
+
 ## v0.10.0
 
 >2026-05-03

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY frontend/ ./
 RUN npm run build
 
 FROM python:3.12-alpine AS runtime
-ARG APP_VERSION=0.10.0
+ARG APP_VERSION=0.10.1
 
 LABEL name="MediaLyze"
 LABEL org.opencontainers.image.source="https://github.com/frederikemmer/MediaLyze"

--- a/desktop/ffprobe-paths.cjs
+++ b/desktop/ffprobe-paths.cjs
@@ -56,6 +56,13 @@ function prependLibraryPath(libraryPath, existingValue) {
   return [libraryPath, existingValue].filter(Boolean).join(":");
 }
 
+function isPackagedFfprobePath(candidate, resourcesPath, platform = process.platform) {
+  if (!candidate || !resourcesPath) {
+    return false;
+  }
+  return packagedFfprobeCandidates(resourcesPath, platform).includes(candidate);
+}
+
 function resolveFfprobePath({
   isPackaged,
   resourcesPath,
@@ -83,11 +90,47 @@ function resolveFfprobePath({
   return "ffprobe";
 }
 
+function resolveFfprobeEnvironment({
+  isPackaged,
+  resourcesPath,
+  env = process.env,
+  platform = process.platform,
+  exists = existsSync,
+} = {}) {
+  const ffprobePath = resolveFfprobePath({
+    isPackaged,
+    resourcesPath,
+    env,
+    platform,
+    exists,
+  });
+  const resolvedEnv = {
+    FFPROBE_PATH: ffprobePath,
+  };
+
+  if (isPackagedFfprobePath(ffprobePath, resourcesPath, platform)) {
+    const libraryPath = resolveFfprobeLibraryPath({
+      isPackaged,
+      resourcesPath,
+      platform,
+      exists,
+    });
+    const ldLibraryPath = prependLibraryPath(libraryPath, env.LD_LIBRARY_PATH);
+    if (ldLibraryPath) {
+      resolvedEnv.LD_LIBRARY_PATH = ldLibraryPath;
+    }
+  }
+
+  return resolvedEnv;
+}
+
 module.exports = {
   bundledFfprobeName,
+  isPackagedFfprobePath,
   packagedFfprobeLibraryCandidates,
   packagedFfprobeCandidates,
   prependLibraryPath,
+  resolveFfprobeEnvironment,
   resolveFfprobeLibraryPath,
   resolveFfprobePath,
 };

--- a/desktop/ffprobe-paths.cjs
+++ b/desktop/ffprobe-paths.cjs
@@ -23,6 +23,39 @@ function packagedFfprobeCandidates(resourcesPath, platform = process.platform) {
   ];
 }
 
+function packagedFfprobeLibraryCandidates(resourcesPath) {
+  return [
+    path.join(resourcesPath, "backend", "ffprobe", "lib"),
+    path.join(resourcesPath, "ffprobe", "lib"),
+  ];
+}
+
+function resolveFfprobeLibraryPath({
+  isPackaged,
+  resourcesPath,
+  platform = process.platform,
+  exists = existsSync,
+} = {}) {
+  if (!isPackaged || platform !== "linux" || !resourcesPath) {
+    return null;
+  }
+
+  for (const candidate of packagedFfprobeLibraryCandidates(resourcesPath)) {
+    if (exists(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function prependLibraryPath(libraryPath, existingValue) {
+  if (!libraryPath) {
+    return existingValue;
+  }
+  return [libraryPath, existingValue].filter(Boolean).join(":");
+}
+
 function resolveFfprobePath({
   isPackaged,
   resourcesPath,
@@ -52,6 +85,9 @@ function resolveFfprobePath({
 
 module.exports = {
   bundledFfprobeName,
+  packagedFfprobeLibraryCandidates,
   packagedFfprobeCandidates,
+  prependLibraryPath,
+  resolveFfprobeLibraryPath,
   resolveFfprobePath,
 };

--- a/desktop/ffprobe-paths.test.cjs
+++ b/desktop/ffprobe-paths.test.cjs
@@ -2,9 +2,11 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
+  isPackagedFfprobePath,
   packagedFfprobeLibraryCandidates,
   packagedFfprobeCandidates,
   prependLibraryPath,
+  resolveFfprobeEnvironment,
   resolveFfprobeLibraryPath,
   resolveFfprobePath,
 } = require("./ffprobe-paths.cjs");
@@ -86,4 +88,56 @@ test("prependLibraryPath prepends bundled library directory without dropping exi
 
 test("prependLibraryPath leaves existing value alone when no bundled library path exists", () => {
   assert.equal(prependLibraryPath(null, "/usr/local/lib"), "/usr/local/lib");
+});
+
+test("isPackagedFfprobePath detects bundled candidates only", () => {
+  const candidates = packagedFfprobeCandidates("/app/resources", "linux");
+
+  assert.equal(
+    isPackagedFfprobePath(candidates[0], "/app/resources", "linux"),
+    true
+  );
+  assert.equal(
+    isPackagedFfprobePath("/usr/local/bin/ffprobe", "/app/resources", "linux"),
+    false
+  );
+});
+
+test("resolveFfprobeEnvironment honors system override without bundled libraries", () => {
+  const resolved = resolveFfprobeEnvironment({
+    isPackaged: true,
+    resourcesPath: "/app/resources",
+    platform: "linux",
+    env: {
+      FFPROBE_PATH: "/usr/local/bin/ffprobe",
+      LD_LIBRARY_PATH: "/usr/local/lib",
+    },
+    exists: (candidate) =>
+      candidate === "/usr/local/bin/ffprobe" ||
+      candidate === "/app/resources/backend/ffprobe/lib",
+  });
+
+  assert.deepEqual(resolved, {
+    FFPROBE_PATH: "/usr/local/bin/ffprobe",
+  });
+});
+
+test("resolveFfprobeEnvironment adds bundled libraries for bundled Linux ffprobe", () => {
+  const ffprobeCandidates = packagedFfprobeCandidates("/app/resources", "linux");
+  const libraryCandidates = packagedFfprobeLibraryCandidates("/app/resources");
+  const resolved = resolveFfprobeEnvironment({
+    isPackaged: true,
+    resourcesPath: "/app/resources",
+    platform: "linux",
+    env: {
+      LD_LIBRARY_PATH: "/usr/local/lib",
+    },
+    exists: (candidate) =>
+      candidate === ffprobeCandidates[0] || candidate === libraryCandidates[0],
+  });
+
+  assert.deepEqual(resolved, {
+    FFPROBE_PATH: ffprobeCandidates[0],
+    LD_LIBRARY_PATH: `${libraryCandidates[0]}:/usr/local/lib`,
+  });
 });

--- a/desktop/ffprobe-paths.test.cjs
+++ b/desktop/ffprobe-paths.test.cjs
@@ -2,7 +2,10 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
+  packagedFfprobeLibraryCandidates,
   packagedFfprobeCandidates,
+  prependLibraryPath,
+  resolveFfprobeLibraryPath,
   resolveFfprobePath,
 } = require("./ffprobe-paths.cjs");
 
@@ -49,4 +52,38 @@ test("resolveFfprobePath defaults to PATH lookup in development", () => {
   });
 
   assert.equal(resolved, "ffprobe");
+});
+
+test("resolveFfprobeLibraryPath returns packaged Linux ffprobe lib directory", () => {
+  const candidates = packagedFfprobeLibraryCandidates("/app/resources");
+  const resolved = resolveFfprobeLibraryPath({
+    isPackaged: true,
+    resourcesPath: "/app/resources",
+    platform: "linux",
+    exists: (candidate) => candidate === candidates[0],
+  });
+
+  assert.equal(resolved, candidates[0]);
+});
+
+test("resolveFfprobeLibraryPath is disabled outside packaged Linux builds", () => {
+  const resolved = resolveFfprobeLibraryPath({
+    isPackaged: true,
+    resourcesPath: "/app/resources",
+    platform: "darwin",
+    exists: () => true,
+  });
+
+  assert.equal(resolved, null);
+});
+
+test("prependLibraryPath prepends bundled library directory without dropping existing paths", () => {
+  assert.equal(
+    prependLibraryPath("/app/resources/backend/ffprobe/lib", "/usr/local/lib"),
+    "/app/resources/backend/ffprobe/lib:/usr/local/lib"
+  );
+});
+
+test("prependLibraryPath leaves existing value alone when no bundled library path exists", () => {
+  assert.equal(prependLibraryPath(null, "/usr/local/lib"), "/usr/local/lib");
 });

--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -3,7 +3,11 @@ const http = require("node:http");
 const net = require("node:net");
 const path = require("node:path");
 const { spawn } = require("node:child_process");
-const { resolveFfprobePath } = require("./ffprobe-paths.cjs");
+const {
+  prependLibraryPath,
+  resolveFfprobeLibraryPath,
+  resolveFfprobePath,
+} = require("./ffprobe-paths.cjs");
 
 let mainWindow = null;
 let backendProcess = null;
@@ -115,21 +119,33 @@ function startBackend(port) {
   const launch = resolveBackendCommand();
   const configPath = app.getPath("userData");
   const isPackagedWindows = app.isPackaged && process.platform === "win32";
+  const ffprobeLibraryPath = resolveFfprobeLibraryPath({
+    isPackaged: app.isPackaged,
+    resourcesPath: process.resourcesPath,
+  });
+  const backendEnv = {
+    ...process.env,
+    MEDIALYZE_RUNTIME: "desktop",
+    APP_HOST: "127.0.0.1",
+    APP_PORT: String(port),
+    CONFIG_PATH: configPath,
+    FRONTEND_DIST_PATH: resolveFrontendDistPath(),
+    FFPROBE_PATH: resolveFfprobePath({
+      isPackaged: app.isPackaged,
+      resourcesPath: process.resourcesPath,
+    }),
+    PYTHONUNBUFFERED: "1",
+  };
+  if (ffprobeLibraryPath) {
+    backendEnv.LD_LIBRARY_PATH = prependLibraryPath(
+      ffprobeLibraryPath,
+      process.env.LD_LIBRARY_PATH
+    );
+  }
+
   backendProcess = spawn(launch.command, launch.args, {
     cwd: launch.cwd,
-    env: {
-      ...process.env,
-      MEDIALYZE_RUNTIME: "desktop",
-      APP_HOST: "127.0.0.1",
-      APP_PORT: String(port),
-      CONFIG_PATH: configPath,
-      FRONTEND_DIST_PATH: resolveFrontendDistPath(),
-      FFPROBE_PATH: resolveFfprobePath({
-        isPackaged: app.isPackaged,
-        resourcesPath: process.resourcesPath,
-      }),
-      PYTHONUNBUFFERED: "1",
-    },
+    env: backendEnv,
     stdio: isPackagedWindows ? "ignore" : "inherit",
     windowsHide: isPackagedWindows,
   });

--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -4,9 +4,7 @@ const net = require("node:net");
 const path = require("node:path");
 const { spawn } = require("node:child_process");
 const {
-  prependLibraryPath,
-  resolveFfprobeLibraryPath,
-  resolveFfprobePath,
+  resolveFfprobeEnvironment,
 } = require("./ffprobe-paths.cjs");
 
 let mainWindow = null;
@@ -119,10 +117,6 @@ function startBackend(port) {
   const launch = resolveBackendCommand();
   const configPath = app.getPath("userData");
   const isPackagedWindows = app.isPackaged && process.platform === "win32";
-  const ffprobeLibraryPath = resolveFfprobeLibraryPath({
-    isPackaged: app.isPackaged,
-    resourcesPath: process.resourcesPath,
-  });
   const backendEnv = {
     ...process.env,
     MEDIALYZE_RUNTIME: "desktop",
@@ -130,18 +124,12 @@ function startBackend(port) {
     APP_PORT: String(port),
     CONFIG_PATH: configPath,
     FRONTEND_DIST_PATH: resolveFrontendDistPath(),
-    FFPROBE_PATH: resolveFfprobePath({
+    ...resolveFfprobeEnvironment({
       isPackaged: app.isPackaged,
       resourcesPath: process.resourcesPath,
     }),
     PYTHONUNBUFFERED: "1",
   };
-  if (ffprobeLibraryPath) {
-    backendEnv.LD_LIBRARY_PATH = prependLibraryPath(
-      ffprobeLibraryPath,
-      process.env.LD_LIBRARY_PATH
-    );
-  }
 
   backendProcess = spawn(launch.command, launch.args, {
     cwd: launch.cwd,

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medialyze-desktop",
-  "version": "0.9.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medialyze-desktop",
-      "version": "0.9.0",
+      "version": "0.10.1",
       "devDependencies": {
         "electron": "^39.8.5",
         "electron-builder": "^26.0.12",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medialyze-desktop",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "description": "Desktop packaging for the MediaLyze local media analysis app.",
   "author": "Frederik Emmer",

--- a/desktop/scripts/build-backend.mjs
+++ b/desktop/scripts/build-backend.mjs
@@ -144,6 +144,97 @@ export function parseOtoolRpaths(stdout) {
   return rpaths;
 }
 
+export function parseLddDependencies(stdout) {
+  return stdout
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const linkedMatch = line.match(/^[^\s]+ => (\/[^\s]+) \(/);
+      if (linkedMatch) {
+        return linkedMatch[1];
+      }
+      const directMatch = line.match(/^(\/[^\s]+) \(/);
+      if (directMatch) {
+        return directMatch[1];
+      }
+      return null;
+    })
+    .filter(Boolean);
+}
+
+function defaultInspectElfBinary(binaryPath) {
+  const dependencyResult = runCommand("ldd", [binaryPath]);
+  return {
+    dependencies: parseLddDependencies(dependencyResult.stdout ?? ""),
+  };
+}
+
+function isLinuxRuntimeDependency(candidate, pathLib = path) {
+  const basename = pathLib.basename(candidate);
+  return (
+    basename.startsWith("ld-linux") ||
+    /^lib(c|m|dl|pthread|rt|resolv|nsl|util|gcc_s)\.so/.test(basename)
+  );
+}
+
+export function bundleLinuxFfprobeDependencies(
+  bundleDir,
+  executablePath,
+  {
+    copy = cpSync,
+    exists = existsSync,
+    inspectBinary = defaultInspectElfBinary,
+    mkdir = mkdirSync,
+    pathLib = path,
+    realpath = realpathSync,
+    sourceExecutablePath = executablePath,
+  } = {}
+) {
+  const libDir = pathLib.join(bundleDir, "lib");
+  const pendingBinaries = [sourceExecutablePath];
+  const inspected = new Set();
+  const copiedLibraries = new Map();
+
+  while (pendingBinaries.length > 0) {
+    const sourcePath = pendingBinaries.pop();
+    const realSourcePath = realpath(sourcePath);
+    if (inspected.has(realSourcePath)) {
+      continue;
+    }
+    inspected.add(realSourcePath);
+
+    const inspection = inspectBinary(sourcePath);
+    for (const dependency of inspection.dependencies) {
+      if (isLinuxRuntimeDependency(dependency, pathLib) || !exists(dependency)) {
+        continue;
+      }
+
+      const realDependency = realpath(dependency);
+      if (copiedLibraries.has(realDependency)) {
+        continue;
+      }
+
+      mkdir(libDir, { recursive: true });
+      const bundledDependency = pathLib.join(
+        libDir,
+        pathLib.basename(realDependency)
+      );
+      copy(realDependency, bundledDependency);
+      copiedLibraries.set(realDependency, bundledDependency);
+      pendingBinaries.push(realDependency);
+    }
+  }
+
+  for (const bundledDependency of copiedLibraries.values()) {
+    if (!exists(bundledDependency)) {
+      throw new Error(
+        `Bundled ffprobe dependency missing after copy: ${bundledDependency}`
+      );
+    }
+  }
+}
+
 function defaultInspectMachOBinary(binaryPath) {
   const dependencyResult = runCommand("otool", ["-L", binaryPath]);
   const loadCommandResult = runCommand("otool", ["-l", binaryPath]);
@@ -362,8 +453,15 @@ export function bundleFfprobe(outputPath, options = {}) {
   if (source.kind === "directory") {
     cpSync(source.sourcePath, targetDir, { recursive: true });
     const bundledExecutable = path.join(targetDir, source.executableName);
-    if ((options.platform ?? process.platform) === "darwin") {
+    const platform = options.platform ?? process.platform;
+    if (platform === "darwin") {
       bundleMacosFfprobeDependencies(targetDir, bundledExecutable, {
+        ...options,
+        sourceExecutablePath: path.join(source.sourcePath, source.executableName),
+      });
+    }
+    if (platform === "linux") {
+      bundleLinuxFfprobeDependencies(targetDir, bundledExecutable, {
         ...options,
         sourceExecutablePath: path.join(source.sourcePath, source.executableName),
       });
@@ -379,8 +477,15 @@ export function bundleFfprobe(outputPath, options = {}) {
     sourceExecutable,
     targetExecutable
   );
-  if ((options.platform ?? process.platform) === "darwin") {
+  const platform = options.platform ?? process.platform;
+  if (platform === "darwin") {
     bundleMacosFfprobeDependencies(targetDir, targetExecutable, {
+      ...options,
+      sourceExecutablePath: sourceExecutable,
+    });
+  }
+  if (platform === "linux") {
+    bundleLinuxFfprobeDependencies(targetDir, targetExecutable, {
       ...options,
       sourceExecutablePath: sourceExecutable,
     });

--- a/desktop/scripts/build-backend.test.mjs
+++ b/desktop/scripts/build-backend.test.mjs
@@ -12,9 +12,11 @@ import os from "node:os";
 import path from "node:path";
 
 import {
+  bundleLinuxFfprobeDependencies,
   bundleMacosFfprobeDependencies,
   bundleFfprobe,
   bundledFfprobeName,
+  parseLddDependencies,
   parseOtoolDependencies,
   parseOtoolRpaths,
   resolveBundledFfprobeSource,
@@ -90,6 +92,43 @@ test("bundleFfprobe creates the expected ffprobe folder structure", () => {
   });
 });
 
+test("bundleFfprobe includes Linux ffprobe shared-library dependencies", () => {
+  withTempDir((tempDir) => {
+    const sourceBinary = path.join(tempDir, "source", "ffprobe");
+    const sourceLib = path.join(tempDir, "system-lib", "libavdevice.so.60");
+    const outputDir = path.join(tempDir, "desktop-backend");
+    mkdirSync(path.dirname(sourceBinary), { recursive: true });
+    mkdirSync(path.dirname(sourceLib), { recursive: true });
+    mkdirSync(outputDir, { recursive: true });
+    writeFileSync(sourceBinary, "ffprobe-binary");
+    writeFileSync(sourceLib, "avdevice");
+
+    bundleFfprobe(outputDir, {
+      env: { MEDIALYZE_FFPROBE_DIR: sourceBinary },
+      platform: "linux",
+      realpath: (candidate) => candidate,
+      inspectBinary: (candidate) => {
+        if (candidate === sourceBinary) {
+          return {
+            dependencies: [sourceLib],
+          };
+        }
+        if (candidate === sourceLib) {
+          return {
+            dependencies: [],
+          };
+        }
+        throw new Error(`Unexpected inspect target: ${candidate}`);
+      },
+    });
+
+    assert.equal(
+      readFileSync(path.join(outputDir, "ffprobe", "lib", "libavdevice.so.60"), "utf8"),
+      "avdevice"
+    );
+  });
+});
+
 test("parseOtoolDependencies extracts linked library paths", () => {
   const dependencies = parseOtoolDependencies(`/tmp/ffprobe:
 \t/opt/homebrew/Cellar/ffmpeg/8.1/lib/libavdevice.62.dylib (compatibility version 62.0.0, current version 62.3.100)
@@ -115,6 +154,77 @@ Load command 12
 `);
 
   assert.deepEqual(rpaths, ["@loader_path/../lib", "/opt/homebrew/lib"]);
+});
+
+test("parseLddDependencies extracts linked ELF library paths", () => {
+  const dependencies = parseLddDependencies(`linux-vdso.so.1 (0x00007ffc2b1f9000)
+\tlibavdevice.so.60 => /lib/x86_64-linux-gnu/libavdevice.so.60 (0x00007f95aeb00000)
+\tlibmissing.so.1 => not found
+\t/lib64/ld-linux-x86-64.so.2 (0x00007f95b0400000)
+`);
+
+  assert.deepEqual(dependencies, [
+    "/lib/x86_64-linux-gnu/libavdevice.so.60",
+    "/lib64/ld-linux-x86-64.so.2",
+  ]);
+});
+
+test("bundleLinuxFfprobeDependencies copies non-runtime ELF dependencies recursively", () => {
+  const pathLib = path.posix;
+  const bundleDir = "/bundle/ffprobe";
+  const libDir = pathLib.join(bundleDir, "lib");
+  const executablePath = pathLib.join(bundleDir, "ffprobe");
+  const sourceExecutablePath = "/source/ffprobe";
+  const avdevicePath = "/lib/x86_64-linux-gnu/libavdevice.so.60";
+  const avutilPath = "/lib/x86_64-linux-gnu/libavutil.so.58";
+  const libcPath = "/lib/x86_64-linux-gnu/libc.so.6";
+  const loaderPath = "/lib64/ld-linux-x86-64.so.2";
+
+  const directories = new Set([bundleDir, "/source", "/lib/x86_64-linux-gnu", "/lib64"]);
+  const files = new Map([
+    [executablePath, "ffprobe-binary"],
+    [sourceExecutablePath, "ffprobe-source"],
+    [avdevicePath, "avdevice"],
+    [avutilPath, "avutil"],
+    [libcPath, "libc"],
+    [loaderPath, "loader"],
+  ]);
+
+  bundleLinuxFfprobeDependencies(bundleDir, executablePath, {
+    sourceExecutablePath,
+    pathLib,
+    copy: (sourcePath, targetPath) => {
+      files.set(targetPath, files.get(sourcePath) ?? "");
+    },
+    exists: (candidate) => files.has(candidate) || directories.has(candidate),
+    inspectBinary: (candidate) => {
+      if (candidate === sourceExecutablePath) {
+        return {
+          dependencies: [avdevicePath, loaderPath],
+        };
+      }
+      if (candidate === avdevicePath) {
+        return {
+          dependencies: [avutilPath, libcPath],
+        };
+      }
+      if (candidate === avutilPath) {
+        return {
+          dependencies: [libcPath],
+        };
+      }
+      throw new Error(`Unexpected inspect target: ${candidate}`);
+    },
+    mkdir: (directoryPath) => {
+      directories.add(directoryPath);
+    },
+    realpath: (candidate) => candidate,
+  });
+
+  assert.equal(files.get(pathLib.join(libDir, "libavdevice.so.60")), "avdevice");
+  assert.equal(files.get(pathLib.join(libDir, "libavutil.so.58")), "avutil");
+  assert.equal(files.has(pathLib.join(libDir, "libc.so.6")), false);
+  assert.equal(files.has(pathLib.join(libDir, "ld-linux-x86-64.so.2")), false);
 });
 
 test(

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medialyze-frontend",
-  "version": "0.9.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medialyze-frontend",
-      "version": "0.9.0",
+      "version": "0.10.1",
       "dependencies": {
         "@tanstack/react-virtual": "^3.13.21",
         "echarts": "^6.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medialyze-frontend",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "medialyze"
-version = "0.10.0"
+version = "0.10.1"
 description = "Self-hosted media library analyzer for technical video metadata."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Bundle Linux desktop `ffprobe` shared-library dependencies into AppImage builds to prevent scan failures due to incompatible FFmpeg library versions. Implement functions to improve `ffprobe` path resolution and environment handling.

## Changes

- Added functions for resolving `ffprobe` environment and paths
- Updated AppImage build process to include necessary `ffprobe` libraries

## Testing

- Verified that the bundled `ffprobe` executable and libraries are present in the AppImage

## Checklist

- [x] I tested the change locally.
- [x] I updated docs if behavior/config changed.
- [x] I kept the scope focused (single concern).
- [x] I did not include secrets or local machine artifacts.

