### PR TITLE
possible fix for linux ffprobe error

### DIFF
--- a/.github/workflows/build-desktop-dev.yaml
+++ b/.github/workflows/build-desktop-dev.yaml
@@ -117,10 +117,22 @@ jobs:
 
           ffprobe_dir="squashfs-root/resources/backend/ffprobe"
           ffprobe_bin="$ffprobe_dir/ffprobe"
+          ffprobe_launcher="$ffprobe_dir/ffprobe-medialyze"
           ffprobe_lib="$ffprobe_dir/lib"
 
           if [[ ! -x "$ffprobe_bin" ]]; then
             echo "Bundled ffprobe executable is missing from AppImage: $ffprobe_bin" >&2
+            exit 1
+          fi
+
+          if [[ ! -x "$ffprobe_launcher" ]]; then
+            echo "Bundled ffprobe launcher is missing from AppImage: $ffprobe_launcher" >&2
+            exit 1
+          fi
+
+          if ! grep -q 'LD_LIBRARY_PATH="$SELF_DIR/lib' "$ffprobe_launcher"; then
+            echo "Bundled ffprobe launcher does not set LD_LIBRARY_PATH from its own lib directory." >&2
+            sed -n '1,40p' "$ffprobe_launcher" >&2
             exit 1
           fi
 
@@ -140,6 +152,8 @@ jobs:
             LD_LIBRARY_PATH="$PWD/$ffprobe_lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ldd "$ffprobe_bin" >&2
             exit 1
           fi
+
+          "$ffprobe_launcher" -version >/dev/null
 
       - name: Upload Linux desktop artifact
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/build-desktop.yaml
+++ b/.github/workflows/build-desktop.yaml
@@ -163,10 +163,22 @@ jobs:
 
           ffprobe_dir="squashfs-root/resources/backend/ffprobe"
           ffprobe_bin="$ffprobe_dir/ffprobe"
+          ffprobe_launcher="$ffprobe_dir/ffprobe-medialyze"
           ffprobe_lib="$ffprobe_dir/lib"
 
           if [[ ! -x "$ffprobe_bin" ]]; then
             echo "Bundled ffprobe executable is missing from AppImage: $ffprobe_bin" >&2
+            exit 1
+          fi
+
+          if [[ ! -x "$ffprobe_launcher" ]]; then
+            echo "Bundled ffprobe launcher is missing from AppImage: $ffprobe_launcher" >&2
+            exit 1
+          fi
+
+          if ! grep -q 'LD_LIBRARY_PATH="$SELF_DIR/lib' "$ffprobe_launcher"; then
+            echo "Bundled ffprobe launcher does not set LD_LIBRARY_PATH from its own lib directory." >&2
+            sed -n '1,40p' "$ffprobe_launcher" >&2
             exit 1
           fi
 
@@ -186,6 +198,8 @@ jobs:
             LD_LIBRARY_PATH="$PWD/$ffprobe_lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ldd "$ffprobe_bin" >&2
             exit 1
           fi
+
+          "$ffprobe_launcher" -version >/dev/null
 
       - name: Upload desktop asset to GitHub release
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## vUnreleased
 
+## v0.10.2
+
+>2026-05-06
+
+- route packaged Linux desktop analysis through a bundled `ffprobe` launcher that sets its own library path before executing `ffprobe`, preventing AppImage scans from falling back to incompatible host FFmpeg libraries; `FFPROBE_PATH` still supports explicit system `ffprobe` overrides ([#127](https://github.com/frederikemmer/MediaLyze/issues/127))
+- make `MediaLyze.AppImage --version` print the packaged desktop app version so users can verify the exact AppImage build they are running ([#127](https://github.com/frederikemmer/MediaLyze/issues/127))
+
 ## v0.10.1
 
 >2026-05-04

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY frontend/ ./
 RUN npm run build
 
 FROM python:3.12-alpine AS runtime
-ARG APP_VERSION=0.10.1
+ARG APP_VERSION=0.10.2
 
 LABEL name="MediaLyze"
 LABEL org.opencontainers.image.source="https://github.com/frederikemmer/MediaLyze"

--- a/desktop/ffprobe-paths.cjs
+++ b/desktop/ffprobe-paths.cjs
@@ -5,6 +5,10 @@ function bundledFfprobeName(platform = process.platform) {
   return platform === "win32" ? "ffprobe.exe" : "ffprobe";
 }
 
+function bundledFfprobeLauncherName(platform = process.platform) {
+  return platform === "linux" ? "ffprobe-medialyze" : bundledFfprobeName(platform);
+}
+
 function normalizeEnvPath(value) {
   if (typeof value !== "string") {
     return null;
@@ -15,11 +19,13 @@ function normalizeEnvPath(value) {
 
 function packagedFfprobeCandidates(resourcesPath, platform = process.platform) {
   const executableName = bundledFfprobeName(platform);
+  const launcherName = bundledFfprobeLauncherName(platform);
+  const names = launcherName === executableName ? [executableName] : [launcherName, executableName];
   return [
-    path.join(resourcesPath, "backend", "ffprobe", executableName),
-    path.join(resourcesPath, "backend", "ffprobe", "bin", executableName),
-    path.join(resourcesPath, "ffprobe", executableName),
-    path.join(resourcesPath, "ffprobe", "bin", executableName),
+    ...names.map((name) => path.join(resourcesPath, "backend", "ffprobe", name)),
+    ...names.map((name) => path.join(resourcesPath, "backend", "ffprobe", "bin", name)),
+    ...names.map((name) => path.join(resourcesPath, "ffprobe", name)),
+    ...names.map((name) => path.join(resourcesPath, "ffprobe", "bin", name)),
   ];
 }
 
@@ -125,6 +131,7 @@ function resolveFfprobeEnvironment({
 }
 
 module.exports = {
+  bundledFfprobeLauncherName,
   bundledFfprobeName,
   isPackagedFfprobePath,
   packagedFfprobeLibraryCandidates,

--- a/desktop/ffprobe-paths.test.cjs
+++ b/desktop/ffprobe-paths.test.cjs
@@ -2,6 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
+  bundledFfprobeLauncherName,
   isPackagedFfprobePath,
   packagedFfprobeLibraryCandidates,
   packagedFfprobeCandidates,
@@ -10,6 +11,12 @@ const {
   resolveFfprobeLibraryPath,
   resolveFfprobePath,
 } = require("./ffprobe-paths.cjs");
+
+test("bundledFfprobeLauncherName uses a Linux wrapper", () => {
+  assert.equal(bundledFfprobeLauncherName("linux"), "ffprobe-medialyze");
+  assert.equal(bundledFfprobeLauncherName("darwin"), "ffprobe");
+  assert.equal(bundledFfprobeLauncherName("win32"), "ffprobe.exe");
+});
 
 test("resolveFfprobePath prefers an explicit existing override in packaged mode", () => {
   const resolved = resolveFfprobePath({
@@ -23,16 +30,16 @@ test("resolveFfprobePath prefers an explicit existing override in packaged mode"
 });
 
 test("resolveFfprobePath falls back to bundled packaged candidates", () => {
-  const candidates = packagedFfprobeCandidates("/app/resources", "win32");
+  const candidates = packagedFfprobeCandidates("/app/resources", "linux");
   const resolved = resolveFfprobePath({
     isPackaged: true,
     resourcesPath: "/app/resources",
-    platform: "win32",
+    platform: "linux",
     env: {},
-    exists: (candidate) => candidate === candidates[1],
+    exists: (candidate) => candidate === candidates[0],
   });
 
-  assert.equal(resolved, candidates[1]);
+  assert.equal(resolved, candidates[0]);
 });
 
 test("resolveFfprobePath keeps an explicit override when packaged candidates are missing", () => {
@@ -139,5 +146,23 @@ test("resolveFfprobeEnvironment adds bundled libraries for bundled Linux ffprobe
   assert.deepEqual(resolved, {
     FFPROBE_PATH: ffprobeCandidates[0],
     LD_LIBRARY_PATH: `${libraryCandidates[0]}:/usr/local/lib`,
+  });
+});
+
+test("resolveFfprobeEnvironment falls back to bundled binary when wrapper is missing", () => {
+  const ffprobeCandidates = packagedFfprobeCandidates("/app/resources", "linux");
+  const libraryCandidates = packagedFfprobeLibraryCandidates("/app/resources");
+  const resolved = resolveFfprobeEnvironment({
+    isPackaged: true,
+    resourcesPath: "/app/resources",
+    platform: "linux",
+    env: {},
+    exists: (candidate) =>
+      candidate === ffprobeCandidates[1] || candidate === libraryCandidates[0],
+  });
+
+  assert.deepEqual(resolved, {
+    FFPROBE_PATH: ffprobeCandidates[1],
+    LD_LIBRARY_PATH: libraryCandidates[0],
   });
 });

--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -12,6 +12,11 @@ let backendProcess = null;
 let quitting = false;
 let backendPort = null;
 
+if (process.argv.includes("--version")) {
+  console.log(app.getVersion());
+  app.exit(0);
+}
+
 function repoRoot() {
   return path.resolve(__dirname, "..");
 }

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medialyze-desktop",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medialyze-desktop",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "devDependencies": {
         "electron": "^39.8.5",
         "electron-builder": "^26.0.12",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medialyze-desktop",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "description": "Desktop packaging for the MediaLyze local media analysis app.",
   "author": "Frederik Emmer",

--- a/desktop/scripts/build-backend.mjs
+++ b/desktop/scripts/build-backend.mjs
@@ -1,10 +1,12 @@
 import {
   cpSync,
   existsSync,
+  chmodSync,
   mkdirSync,
   realpathSync,
   rmSync,
   statSync,
+  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -19,6 +21,10 @@ const specDir = path.join(repoRoot, "dist", "pyinstaller-spec");
 
 export function bundledFfprobeName(platform = process.platform) {
   return platform === "win32" ? "ffprobe.exe" : "ffprobe";
+}
+
+export function bundledFfprobeLauncherName(platform = process.platform) {
+  return platform === "linux" ? "ffprobe-medialyze" : bundledFfprobeName(platform);
 }
 
 function runCommand(command, args, options = {}) {
@@ -233,6 +239,30 @@ export function bundleLinuxFfprobeDependencies(
       );
     }
   }
+}
+
+export function writeLinuxFfprobeLauncher(
+  bundleDir,
+  executableName = bundledFfprobeName("linux"),
+  {
+    chmod = chmodSync,
+    pathLib = path,
+    writeFile = writeFileSync,
+  } = {}
+) {
+  const launcherName = bundledFfprobeLauncherName("linux");
+  const launcherPath = pathLib.join(bundleDir, launcherName);
+  writeFile(
+    launcherPath,
+    `#!/bin/sh
+set -eu
+SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+export LD_LIBRARY_PATH="$SELF_DIR/lib\${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+exec "$SELF_DIR/${executableName}" "$@"
+`
+  );
+  chmod(launcherPath, 0o755);
+  return launcherPath;
 }
 
 function defaultInspectMachOBinary(binaryPath) {
@@ -465,6 +495,7 @@ export function bundleFfprobe(outputPath, options = {}) {
         ...options,
         sourceExecutablePath: path.join(source.sourcePath, source.executableName),
       });
+      writeLinuxFfprobeLauncher(targetDir, source.executableName, options);
     }
     return bundledExecutable;
   }
@@ -489,6 +520,7 @@ export function bundleFfprobe(outputPath, options = {}) {
       ...options,
       sourceExecutablePath: sourceExecutable,
     });
+    writeLinuxFfprobeLauncher(targetDir, source.executableName, options);
   }
   return targetExecutable;
 }

--- a/desktop/scripts/build-backend.test.mjs
+++ b/desktop/scripts/build-backend.test.mjs
@@ -15,11 +15,13 @@ import {
   bundleLinuxFfprobeDependencies,
   bundleMacosFfprobeDependencies,
   bundleFfprobe,
+  bundledFfprobeLauncherName,
   bundledFfprobeName,
   parseLddDependencies,
   parseOtoolDependencies,
   parseOtoolRpaths,
   resolveBundledFfprobeSource,
+  writeLinuxFfprobeLauncher,
 } from "./build-backend.mjs";
 
 function withTempDir(fn) {
@@ -126,6 +128,29 @@ test("bundleFfprobe includes Linux ffprobe shared-library dependencies", () => {
       readFileSync(path.join(outputDir, "ffprobe", "lib", "libavdevice.so.60"), "utf8"),
       "avdevice"
     );
+    assert.equal(
+      existsSync(path.join(outputDir, "ffprobe", bundledFfprobeLauncherName("linux"))),
+      true
+    );
+  });
+});
+
+test("writeLinuxFfprobeLauncher writes executable wrapper with bundled library path", () => {
+  withTempDir((tempDir) => {
+    const bundleDir = path.join(tempDir, "ffprobe");
+    mkdirSync(bundleDir, { recursive: true });
+    const chmodCalls = [];
+    const launcherPath = writeLinuxFfprobeLauncher(bundleDir, "ffprobe", {
+      chmod: (...args) => {
+        chmodCalls.push(args);
+      },
+    });
+
+    const content = readFileSync(launcherPath, "utf8");
+    assert.equal(path.basename(launcherPath), bundledFfprobeLauncherName("linux"));
+    assert.match(content, /LD_LIBRARY_PATH="\$SELF_DIR\/lib/);
+    assert.match(content, /exec "\$SELF_DIR\/ffprobe" "\$@"/);
+    assert.deepEqual(chmodCalls, [[launcherPath, 0o755]]);
   });
 });
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medialyze-frontend",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medialyze-frontend",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "dependencies": {
         "@tanstack/react-virtual": "^3.13.21",
         "echarts": "^6.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medialyze-frontend",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "medialyze"
-version = "0.10.1"
+version = "0.10.2"
 description = "Self-hosted media library analyzer for technical video metadata."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Route packaged Linux desktop analysis through a bundled `ffprobe` launcher to ensure proper library path settings.

## Changes

- Introduced a launcher script for `ffprobe` that sets the `LD_LIBRARY_PATH` to its own library directory, preventing fallback to incompatible host libraries

## Testing

- Verified that the launcher executes correctly and sets the library path as intended

## Checklist

- [x] I tested the change locally.
- [x] I updated docs if behavior/config changed.
- [x] I kept the scope focused (single concern).
- [x] I did not include secrets or local machine artifacts.

