### PR TITLE
enhance duplicate functionality and some bugfixes

### DIFF
--- a/.github/workflows/build-desktop-dev.yaml
+++ b/.github/workflows/build-desktop-dev.yaml
@@ -47,13 +47,12 @@ jobs:
         run: npm test
         working-directory: desktop
 
-      - name: Install ffmpeg on Linux
+      - name: Build static ffprobe on Linux
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y ffmpeg
-          mkdir -p dist/ffprobe-bundle
-          cp "$(command -v ffprobe)" dist/ffprobe-bundle/ffprobe
+          sudo apt-get install -y build-essential ca-certificates curl nasm pkg-config xz-utils musl-tools binutils
+          desktop/scripts/build-linux-static-ffprobe.sh
 
       - name: Install ffmpeg on macOS
         if: matrix.os == 'macos-latest'
@@ -117,43 +116,45 @@ jobs:
 
           ffprobe_dir="squashfs-root/resources/backend/ffprobe"
           ffprobe_bin="$ffprobe_dir/ffprobe"
-          ffprobe_launcher="$ffprobe_dir/ffprobe-medialyze"
-          ffprobe_lib="$ffprobe_dir/lib"
 
           if [[ ! -x "$ffprobe_bin" ]]; then
             echo "Bundled ffprobe executable is missing from AppImage: $ffprobe_bin" >&2
             exit 1
           fi
 
-          if [[ ! -x "$ffprobe_launcher" ]]; then
-            echo "Bundled ffprobe launcher is missing from AppImage: $ffprobe_launcher" >&2
+          if [[ -e "$ffprobe_dir/ffprobe-medialyze" ]]; then
+            echo "Linux AppImage must not bundle the old ffprobe wrapper." >&2
             exit 1
           fi
 
-          if ! grep -q 'LD_LIBRARY_PATH="$SELF_DIR/lib' "$ffprobe_launcher"; then
-            echo "Bundled ffprobe launcher does not set LD_LIBRARY_PATH from its own lib directory." >&2
-            sed -n '1,40p' "$ffprobe_launcher" >&2
+          if find "$ffprobe_dir" -type f -name 'libav*.so*' | grep -q .; then
+            echo "Linux AppImage must not bundle dynamic FFmpeg shared libraries." >&2
+            find "$ffprobe_dir" -type f -name 'libav*.so*' >&2
             exit 1
           fi
 
-          if [[ ! -d "$ffprobe_lib" ]]; then
-            echo "Bundled ffprobe library directory is missing from AppImage: $ffprobe_lib" >&2
+          if readelf -d "$ffprobe_bin" | grep -q '(NEEDED)'; then
+            echo "Bundled ffprobe is dynamically linked; expected static binary." >&2
+            readelf -d "$ffprobe_bin" >&2
             exit 1
           fi
 
-          if ! find "$ffprobe_lib" -maxdepth 1 -type f -name 'libavdevice.so*' | grep -q .; then
-            echo "Bundled ffprobe library directory does not contain libavdevice.so*" >&2
-            find "$ffprobe_lib" -maxdepth 1 -type f -printf '%f\n' >&2
-            exit 1
-          fi
+          "$ffprobe_bin" -version >/dev/null
 
-          if LD_LIBRARY_PATH="$PWD/$ffprobe_lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ldd "$ffprobe_bin" | grep -q 'not found'; then
-            echo "Bundled ffprobe still has unresolved shared-library dependencies." >&2
-            LD_LIBRARY_PATH="$PWD/$ffprobe_lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ldd "$ffprobe_bin" >&2
-            exit 1
-          fi
+          python3 - <<'PY'
+          import wave
+          from pathlib import Path
 
-          "$ffprobe_launcher" -version >/dev/null
+          path = Path("dist/ffprobe-smoke.wav")
+          with wave.open(str(path), "w") as wav:
+              wav.setnchannels(1)
+              wav.setsampwidth(2)
+              wav.setframerate(8000)
+              wav.writeframes(b"\x00\x00" * 8000)
+          PY
+
+          "$ffprobe_bin" -v error -print_format json -show_format -show_streams dist/ffprobe-smoke.wav >/tmp/ffprobe-smoke.json
+          grep -q '"codec_name": "pcm_s16le"' /tmp/ffprobe-smoke.json
 
       - name: Upload Linux desktop artifact
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/build-desktop-dev.yaml
+++ b/.github/workflows/build-desktop-dev.yaml
@@ -77,10 +77,37 @@ jobs:
           MEDIALYZE_FFPROBE_DIR: ${{ github.workspace }}/dist/ffprobe-bundle
 
       - name: Build desktop release artifacts
+        if: matrix.os != 'windows-latest'
         run: npm run dist -- --publish never
         working-directory: desktop
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
+
+      - name: Build desktop release artifacts on Windows with retry
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        working-directory: desktop
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        run: |
+          $ErrorActionPreference = "Stop"
+          $maxAttempts = 3
+
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host "Windows desktop build attempt $attempt of $maxAttempts"
+
+            npm run dist -- --publish never
+            if ($LASTEXITCODE -eq 0) {
+              exit 0
+            }
+
+            if ($attempt -ge $maxAttempts) {
+              throw "Windows desktop build failed after $maxAttempts attempts."
+            }
+
+            Write-Warning "Windows desktop build failed on attempt $attempt with exit code $LASTEXITCODE. Retrying after 15 seconds."
+            Start-Sleep -Seconds 15
+          }
 
       - name: Verify desktop artifact name
         shell: bash

--- a/.github/workflows/build-desktop.yaml
+++ b/.github/workflows/build-desktop.yaml
@@ -123,10 +123,37 @@ jobs:
           MEDIALYZE_FFPROBE_DIR: ${{ github.workspace }}/dist/ffprobe-bundle
 
       - name: Build desktop release
+        if: matrix.os != 'windows-latest'
         run: npm run dist -- --publish never
         working-directory: desktop
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
+
+      - name: Build desktop release on Windows with retry
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        working-directory: desktop
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+        run: |
+          $ErrorActionPreference = "Stop"
+          $maxAttempts = 3
+
+          for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+            Write-Host "Windows desktop build attempt $attempt of $maxAttempts"
+
+            npm run dist -- --publish never
+            if ($LASTEXITCODE -eq 0) {
+              exit 0
+            }
+
+            if ($attempt -ge $maxAttempts) {
+              throw "Windows desktop build failed after $maxAttempts attempts."
+            }
+
+            Write-Warning "Windows desktop build failed on attempt $attempt with exit code $LASTEXITCODE. Retrying after 15 seconds."
+            Start-Sleep -Seconds 15
+          }
 
       - name: Verify desktop artifact name
         shell: bash

--- a/.github/workflows/build-desktop.yaml
+++ b/.github/workflows/build-desktop.yaml
@@ -66,13 +66,12 @@ jobs:
         run: npm test
         working-directory: desktop
 
-      - name: Install ffmpeg on Linux
+      - name: Build static ffprobe on Linux
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install -y ffmpeg
-          mkdir -p dist/ffprobe-bundle
-          cp "$(command -v ffprobe)" dist/ffprobe-bundle/ffprobe
+          sudo apt-get install -y build-essential ca-certificates curl nasm pkg-config xz-utils musl-tools binutils
+          desktop/scripts/build-linux-static-ffprobe.sh
 
       - name: Install ffmpeg on macOS
         if: matrix.os == 'macos-latest'
@@ -163,43 +162,45 @@ jobs:
 
           ffprobe_dir="squashfs-root/resources/backend/ffprobe"
           ffprobe_bin="$ffprobe_dir/ffprobe"
-          ffprobe_launcher="$ffprobe_dir/ffprobe-medialyze"
-          ffprobe_lib="$ffprobe_dir/lib"
 
           if [[ ! -x "$ffprobe_bin" ]]; then
             echo "Bundled ffprobe executable is missing from AppImage: $ffprobe_bin" >&2
             exit 1
           fi
 
-          if [[ ! -x "$ffprobe_launcher" ]]; then
-            echo "Bundled ffprobe launcher is missing from AppImage: $ffprobe_launcher" >&2
+          if [[ -e "$ffprobe_dir/ffprobe-medialyze" ]]; then
+            echo "Linux AppImage must not bundle the old ffprobe wrapper." >&2
             exit 1
           fi
 
-          if ! grep -q 'LD_LIBRARY_PATH="$SELF_DIR/lib' "$ffprobe_launcher"; then
-            echo "Bundled ffprobe launcher does not set LD_LIBRARY_PATH from its own lib directory." >&2
-            sed -n '1,40p' "$ffprobe_launcher" >&2
+          if find "$ffprobe_dir" -type f -name 'libav*.so*' | grep -q .; then
+            echo "Linux AppImage must not bundle dynamic FFmpeg shared libraries." >&2
+            find "$ffprobe_dir" -type f -name 'libav*.so*' >&2
             exit 1
           fi
 
-          if [[ ! -d "$ffprobe_lib" ]]; then
-            echo "Bundled ffprobe library directory is missing from AppImage: $ffprobe_lib" >&2
+          if readelf -d "$ffprobe_bin" | grep -q '(NEEDED)'; then
+            echo "Bundled ffprobe is dynamically linked; expected static binary." >&2
+            readelf -d "$ffprobe_bin" >&2
             exit 1
           fi
 
-          if ! find "$ffprobe_lib" -maxdepth 1 -type f -name 'libavdevice.so*' | grep -q .; then
-            echo "Bundled ffprobe library directory does not contain libavdevice.so*" >&2
-            find "$ffprobe_lib" -maxdepth 1 -type f -printf '%f\n' >&2
-            exit 1
-          fi
+          "$ffprobe_bin" -version >/dev/null
 
-          if LD_LIBRARY_PATH="$PWD/$ffprobe_lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ldd "$ffprobe_bin" | grep -q 'not found'; then
-            echo "Bundled ffprobe still has unresolved shared-library dependencies." >&2
-            LD_LIBRARY_PATH="$PWD/$ffprobe_lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" ldd "$ffprobe_bin" >&2
-            exit 1
-          fi
+          python3 - <<'PY'
+          import wave
+          from pathlib import Path
 
-          "$ffprobe_launcher" -version >/dev/null
+          path = Path("dist/ffprobe-smoke.wav")
+          with wave.open(str(path), "w") as wav:
+              wav.setnchannels(1)
+              wav.setsampwidth(2)
+              wav.setframerate(8000)
+              wav.writeframes(b"\x00\x00" * 8000)
+          PY
+
+          "$ffprobe_bin" -v error -print_format json -show_format -show_streams dist/ffprobe-smoke.wav >/tmp/ffprobe-smoke.json
+          grep -q '"codec_name": "pcm_s16le"' /tmp/ffprobe-smoke.json
 
       - name: Upload desktop asset to GitHub release
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 - add a dashboard history metric that shows each visible library's file-count share over time
 - add a Windows `scripts/dev-local.ps1` helper that mirrors the existing local realtime development startup flow by booting the reloading backend, waiting for `/api/health`, and then launching the frontend dev server
 
+### 🐛 Bug fixes
+
+- harden Windows desktop GitHub Actions builds by retrying the Electron packaging step when upstream `electron-builder` NSIS resource downloads fail transiently with HTTP 502 responses
+
 ## v0.10.3
 
 >2026-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 ### ✨ New
 
 - allow duplicate groups to be marked as not duplicates so they stay hidden from normal duplicate views while remaining restorable from the duplicates panel
+- add a dashboard history metric that shows each visible library's file-count share over time
 
 ## v0.10.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## vUnreleased
 
+### ✨ New
+
+- allow duplicate groups to be marked as not duplicates so they stay hidden from normal duplicate views while remaining restorable from the duplicates panel
+
 ## v0.10.3
 
 >2026-05-08
+
+### 🐛 Bug fixes
 
 - replace the Linux desktop AppImage `ffprobe` bundle with a pinned static `ffprobe` build so media scans no longer depend on host or bundled FFmpeg shared-library resolution; `FFPROBE_PATH` remains available for explicit system `ffprobe` overrides ([#127](https://github.com/frederikemmer/MediaLyze/issues/127))
 
@@ -14,12 +20,16 @@ All notable changes to this project will be documented in this file.
 
 >2026-05-06
 
+### 🐛 Bug fixes
+
 - route packaged Linux desktop analysis through a bundled `ffprobe` launcher that sets its own library path before executing `ffprobe`, preventing AppImage scans from falling back to incompatible host FFmpeg libraries; `FFPROBE_PATH` still supports explicit system `ffprobe` overrides ([#127](https://github.com/frederikemmer/MediaLyze/issues/127))
 - make `MediaLyze.AppImage --version` print the packaged desktop app version so users can verify the exact AppImage build they are running ([#127](https://github.com/frederikemmer/MediaLyze/issues/127))
 
 ## v0.10.1
 
 >2026-05-04
+
+### 🐛 Bug fixes
 
 - bundle Linux desktop `ffprobe` shared-library dependencies into AppImage builds and load them at runtime so scans no longer fail when the host distribution has incompatible FFmpeg library versions ([#127](https://github.com/frederikemmer/MediaLyze/issues/127))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## vUnreleased
 
+## v0.10.4
+
+>2026-05-08
+
 ### ✨ New
 
 - allow duplicate groups to be marked as not duplicates so they stay hidden from normal duplicate views while remaining restorable from the duplicates panel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 - allow duplicate groups to be marked as not duplicates so they stay hidden from normal duplicate views while remaining restorable from the duplicates panel
 - add a dashboard history metric that shows each visible library's file-count share over time
+- add a Windows `scripts/dev-local.ps1` helper that mirrors the existing local realtime development startup flow by booting the reloading backend, waiting for `/api/health`, and then launching the frontend dev server
 
 ## v0.10.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## vUnreleased
 
+## v0.10.3
+
+>2026-05-08
+
+- replace the Linux desktop AppImage `ffprobe` bundle with a pinned static `ffprobe` build so media scans no longer depend on host or bundled FFmpeg shared-library resolution; `FFPROBE_PATH` remains available for explicit system `ffprobe` overrides ([#127](https://github.com/frederikemmer/MediaLyze/issues/127))
+
 ## v0.10.2
 
 >2026-05-06

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY frontend/ ./
 RUN npm run build
 
 FROM python:3.12-alpine AS runtime
-ARG APP_VERSION=0.10.2
+ARG APP_VERSION=0.10.3
 
 LABEL name="MediaLyze"
 LABEL org.opencontainers.image.source="https://github.com/frederikemmer/MediaLyze"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY frontend/ ./
 RUN npm run build
 
 FROM python:3.12-alpine AS runtime
-ARG APP_VERSION=0.10.3
+ARG APP_VERSION=0.10.4
 
 LABEL name="MediaLyze"
 LABEL org.opencontainers.image.source="https://github.com/frederikemmer/MediaLyze"

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ If you want a different media-path, or external port change `env.example` or `.e
 
 ## Local Development
 
+For a single-command local dev setup, use `scripts/dev-local.sh` on macOS/Linux or `scripts/dev-local.ps1` on Windows.
+
 ### Backend
 
 ```bash
@@ -155,6 +157,28 @@ npm run dev
 ```
 
 The Vite dev server proxies `/api` to `http://127.0.0.1:8080`.
+
+### Combined startup scripts
+
+macOS/Linux:
+
+```bash
+./scripts/dev-local.sh
+```
+
+Windows PowerShell:
+
+```powershell
+.\scripts\dev-local.ps1
+```
+
+Both scripts expect:
+
+- `.venv` with `pip install -e .[dev]`
+- `frontend/node_modules` from `npm --prefix frontend install`
+- a valid `MEDIA_ROOT` directory, defaulting to your Desktop if not overridden
+
+They start the backend with reload enabled, wait for `/api/health`, then launch the Vite dev server in the foreground.
 
 ### Desktop
 

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -10,7 +10,11 @@ from backend.app.core.config import Settings
 from backend.app.schemas.app_settings import AppSettingsRead, AppSettingsUpdate
 from backend.app.schemas.browse import BrowseResponse
 from backend.app.schemas.comparison import ComparisonFieldId, ComparisonResponse
-from backend.app.schemas.duplicates import DuplicateGroupPageRead
+from backend.app.schemas.duplicates import (
+    DuplicateGroupPageRead,
+    DuplicateSuppressionCreate,
+    DuplicateSuppressionRead,
+)
 from backend.app.schemas.history import HistoryReconstructionStatusRead, HistoryStorageRead
 from backend.app.schemas.library import LibraryCreate, LibraryStatistics, LibrarySummary, LibraryUpdate
 from backend.app.schemas.library_history import DashboardHistoryResponse, LibraryHistoryResponse
@@ -35,11 +39,15 @@ from backend.app.schemas.scan import (
     ScanJobRead,
     ScanRequest,
 )
-from backend.app.models.entities import Library, ScanJob, ScanTriggerSource
+from backend.app.models.entities import DuplicateDetectionMode, Library, ScanJob, ScanTriggerSource
 from backend.app.services.app_settings import get_app_settings as load_app_settings
 from backend.app.services.app_settings import update_app_settings
 from backend.app.services.browse import browse_media_root
-from backend.app.services.duplicates import list_library_duplicate_groups
+from backend.app.services.duplicates import (
+    list_library_duplicate_groups,
+    suppress_duplicate_group,
+    unsuppress_duplicate_group,
+)
 from backend.app.services.history_storage import get_cached_history_storage
 from backend.app.services.history_retention import has_active_scan_jobs
 from backend.app.services.library_history_service import get_dashboard_history, get_library_history
@@ -338,12 +346,53 @@ def library_duplicates(
     library_id: int,
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=25, ge=1, le=200),
+    include_suppressed: bool = Query(default=False),
     db: Session = Depends(get_db_session),
 ) -> DuplicateGroupPageRead:
     try:
-        return list_library_duplicate_groups(db, library_id, offset=offset, limit=limit)
+        return list_library_duplicate_groups(
+            db,
+            library_id,
+            offset=offset,
+            limit=limit,
+            include_suppressed=include_suppressed,
+        )
     except ValueError as exc:
         raise HTTPException(status_code=404, detail="Library not found") from exc
+
+
+@router.post(
+    "/libraries/{library_id}/duplicates/suppressions",
+    response_model=DuplicateSuppressionRead,
+    status_code=201,
+)
+def library_duplicate_suppression_create(
+    library_id: int,
+    payload: DuplicateSuppressionCreate,
+    db: Session = Depends(get_db_session),
+) -> DuplicateSuppressionRead:
+    try:
+        suppression = suppress_duplicate_group(db, library_id, payload.mode, payload.signature)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if suppression is None:
+        raise HTTPException(status_code=404, detail="Library not found")
+    return suppression
+
+
+@router.delete("/libraries/{library_id}/duplicates/suppressions", status_code=204)
+def library_duplicate_suppression_delete(
+    library_id: int,
+    mode: DuplicateDetectionMode = Query(...),
+    signature: str = Query(...),
+    db: Session = Depends(get_db_session),
+) -> None:
+    try:
+        deleted = unsuppress_duplicate_group(db, library_id, mode, signature)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Library not found")
 
 
 @router.get("/libraries/{library_id}/history", response_model=LibraryHistoryResponse)

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -211,6 +211,14 @@ SQLITE_INDEX_STATEMENTS: tuple[str, ...] = (
         "ON library_history (library_id, snapshot_day)"
     ),
     "CREATE INDEX IF NOT EXISTS ix_library_history_captured_at ON library_history (captured_at)",
+    (
+        "CREATE UNIQUE INDEX IF NOT EXISTS ix_duplicate_group_suppressions_library_mode_signature "
+        "ON duplicate_group_suppressions (library_id, mode, signature)"
+    ),
+    (
+        "CREATE INDEX IF NOT EXISTS ix_duplicate_group_suppressions_library_mode "
+        "ON duplicate_group_suppressions (library_id, mode)"
+    ),
 )
 
 

--- a/backend/app/models/entities.py
+++ b/backend/app/models/entities.py
@@ -113,6 +113,11 @@ class Library(TimestampMixin, Base):
         cascade="all, delete-orphan",
         passive_deletes=True,
     )
+    duplicate_group_suppressions: Mapped[list[DuplicateGroupSuppression]] = relationship(
+        back_populates="library",
+        cascade="all, delete-orphan",
+        passive_deletes=True,
+    )
     library_history_entries: Mapped[list[LibraryHistory]] = relationship(
         back_populates="library",
         cascade="all, delete-orphan",
@@ -130,6 +135,30 @@ class AppSetting(Base):
 
     key: Mapped[str] = mapped_column(String(64), primary_key=True)
     value: Mapped[dict] = mapped_column(JSON, default=dict, nullable=False)
+
+
+class DuplicateGroupSuppression(TimestampMixin, Base):
+    __tablename__ = "duplicate_group_suppressions"
+    __table_args__ = (
+        Index(
+            "ix_duplicate_group_suppressions_library_mode_signature",
+            "library_id",
+            "mode",
+            "signature",
+            unique=True,
+        ),
+        Index("ix_duplicate_group_suppressions_library_mode", "library_id", "mode"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    library_id: Mapped[int] = mapped_column(ForeignKey("libraries.id", ondelete="CASCADE"), nullable=False)
+    mode: Mapped[DuplicateDetectionMode] = mapped_column(
+        SqlEnum(DuplicateDetectionMode, native_enum=False),
+        nullable=False,
+    )
+    signature: Mapped[str] = mapped_column(String(512), nullable=False)
+
+    library: Mapped[Library] = relationship(back_populates="duplicate_group_suppressions")
 
 
 class MediaSeries(TimestampMixin, Base):

--- a/backend/app/schemas/duplicates.py
+++ b/backend/app/schemas/duplicates.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from pydantic import BaseModel, Field
 
 from backend.app.models.entities import DuplicateDetectionMode
@@ -16,6 +18,7 @@ class DuplicateGroupRead(BaseModel):
     label: str
     file_count: int
     total_size_bytes: int
+    suppressed: bool = False
     items: list[DuplicateGroupFileRead] = Field(default_factory=list)
 
 
@@ -23,6 +26,21 @@ class DuplicateGroupPageRead(BaseModel):
     mode: DuplicateDetectionMode
     total_groups: int = 0
     duplicate_file_count: int = 0
+    include_suppressed: bool = False
+    suppressed_group_count: int = 0
     offset: int = 0
     limit: int = 25
     items: list[DuplicateGroupRead] = Field(default_factory=list)
+
+
+class DuplicateSuppressionCreate(BaseModel):
+    mode: DuplicateDetectionMode
+    signature: str
+
+
+class DuplicateSuppressionRead(BaseModel):
+    id: int
+    library_id: int
+    mode: DuplicateDetectionMode
+    signature: str
+    created_at: datetime

--- a/backend/app/schemas/library_history.py
+++ b/backend/app/schemas/library_history.py
@@ -9,6 +9,11 @@ class LibraryHistoryResolutionCategoryRead(BaseModel):
     label: str
 
 
+class DashboardHistoryLibraryRead(BaseModel):
+    id: int
+    name: str
+
+
 class LibraryHistoryNumericSummaryRead(BaseModel):
     count: int = 0
     sum: float = 0.0
@@ -50,3 +55,4 @@ class LibraryHistoryResponse(HistoryTimelineResponse):
 
 class DashboardHistoryResponse(HistoryTimelineResponse):
     visible_library_ids: list[int] = Field(default_factory=list)
+    visible_libraries: list[DashboardHistoryLibraryRead] = Field(default_factory=list)

--- a/backend/app/services/duplicates.py
+++ b/backend/app/services/duplicates.py
@@ -8,11 +8,16 @@ from pathlib import Path
 import re
 from typing import Protocol
 
-from sqlalchemy import Select, func, select, union
+from sqlalchemy import Select, delete, exists, func, select, union
 from sqlalchemy.orm import Session
 
-from backend.app.models.entities import DuplicateDetectionMode, Library, MediaFile
-from backend.app.schemas.duplicates import DuplicateGroupFileRead, DuplicateGroupPageRead, DuplicateGroupRead
+from backend.app.models.entities import DuplicateDetectionMode, DuplicateGroupSuppression, Library, MediaFile
+from backend.app.schemas.duplicates import (
+    DuplicateGroupFileRead,
+    DuplicateGroupPageRead,
+    DuplicateGroupRead,
+    DuplicateSuppressionRead,
+)
 
 FILE_HASH_ALGORITHM = "sha256"
 FILE_HASH_CHUNK_SIZE = 1024 * 1024
@@ -126,13 +131,102 @@ def get_duplicate_detection_strategy(mode: DuplicateDetectionMode | str) -> Dupl
     return FilenameDuplicateDetectionStrategy()
 
 
-def _active_signature_statement(library_id: int, mode: DuplicateDetectionMode) -> Select:
+def normalize_suppression_mode(mode: DuplicateDetectionMode | str) -> DuplicateDetectionMode:
+    normalized_mode = DuplicateDetectionMode(mode)
+    if normalized_mode not in {DuplicateDetectionMode.filename, DuplicateDetectionMode.filehash}:
+        raise ValueError("Duplicate suppression mode must be filename or filehash")
+    return normalized_mode
+
+
+def _normalize_suppression_signature(signature: str) -> str:
+    normalized_signature = signature.strip()
+    if not normalized_signature:
+        raise ValueError("Duplicate suppression signature must not be empty")
+    return normalized_signature
+
+
+def suppress_duplicate_group(
+    db: Session,
+    library_id: int,
+    mode: DuplicateDetectionMode | str,
+    signature: str,
+) -> DuplicateSuppressionRead | None:
+    if db.get(Library, library_id) is None:
+        return None
+
+    normalized_mode = normalize_suppression_mode(mode)
+    normalized_signature = _normalize_suppression_signature(signature)
+    suppression = db.scalar(
+        select(DuplicateGroupSuppression).where(
+            DuplicateGroupSuppression.library_id == library_id,
+            DuplicateGroupSuppression.mode == normalized_mode,
+            DuplicateGroupSuppression.signature == normalized_signature,
+        )
+    )
+    if suppression is None:
+        suppression = DuplicateGroupSuppression(
+            library_id=library_id,
+            mode=normalized_mode,
+            signature=normalized_signature,
+        )
+        db.add(suppression)
+        db.flush()
+    db.commit()
+    db.refresh(suppression)
+    return DuplicateSuppressionRead(
+        id=suppression.id,
+        library_id=suppression.library_id,
+        mode=suppression.mode,
+        signature=suppression.signature,
+        created_at=suppression.created_at,
+    )
+
+
+def unsuppress_duplicate_group(
+    db: Session,
+    library_id: int,
+    mode: DuplicateDetectionMode | str,
+    signature: str,
+) -> bool:
+    if db.get(Library, library_id) is None:
+        return False
+
+    normalized_mode = normalize_suppression_mode(mode)
+    normalized_signature = _normalize_suppression_signature(signature)
+    db.execute(
+        delete(DuplicateGroupSuppression).where(
+            DuplicateGroupSuppression.library_id == library_id,
+            DuplicateGroupSuppression.mode == normalized_mode,
+            DuplicateGroupSuppression.signature == normalized_signature,
+        )
+    )
+    db.commit()
+    return True
+
+
+def _suppression_exists_expression(library_id: int, mode: DuplicateDetectionMode, signature_column):
+    return exists(
+        select(1).where(
+            DuplicateGroupSuppression.library_id == library_id,
+            DuplicateGroupSuppression.mode == mode,
+            DuplicateGroupSuppression.signature == signature_column,
+        )
+    )
+
+
+def _active_signature_statement(
+    library_id: int,
+    mode: DuplicateDetectionMode,
+    *,
+    include_suppressed: bool = False,
+    suppressed_only: bool = False,
+) -> Select:
     if mode == DuplicateDetectionMode.both:
         raise ValueError("Combined duplicate mode must be expanded before building a signature query")
 
     if mode == DuplicateDetectionMode.filehash:
         signature_column = MediaFile.content_hash
-        return (
+        statement = (
             select(
                 signature_column.label("signature"),
                 func.count(MediaFile.id).label("file_count"),
@@ -148,9 +242,15 @@ def _active_signature_statement(library_id: int, mode: DuplicateDetectionMode) -
             .group_by(signature_column)
             .having(func.count(MediaFile.id) > 1)
         )
+        suppression_exists = _suppression_exists_expression(library_id, mode, signature_column)
+        if suppressed_only:
+            return statement.where(suppression_exists)
+        if not include_suppressed:
+            return statement.where(~suppression_exists)
+        return statement
 
     signature_column = MediaFile.filename_signature
-    return (
+    statement = (
         select(
             signature_column.label("signature"),
             func.count(MediaFile.id).label("file_count"),
@@ -165,6 +265,12 @@ def _active_signature_statement(library_id: int, mode: DuplicateDetectionMode) -
         .group_by(signature_column)
         .having(func.count(MediaFile.id) > 1)
     )
+    suppression_exists = _suppression_exists_expression(library_id, mode, signature_column)
+    if suppressed_only:
+        return statement.where(suppression_exists)
+    if not include_suppressed:
+        return statement.where(~suppression_exists)
+    return statement
 
 
 def _duplicate_file_membership_statement(library_id: int, mode: DuplicateDetectionMode) -> Select:
@@ -213,6 +319,19 @@ def get_duplicate_group_counts(db: Session, library_id: int, mode: DuplicateDete
     return int(total_groups), int(duplicate_file_count)
 
 
+def get_suppressed_duplicate_group_count(db: Session, library_id: int, mode: DuplicateDetectionMode | str) -> int:
+    total_groups = 0
+    for active_mode in get_active_duplicate_detection_modes(mode):
+        grouped = _active_signature_statement(
+            library_id,
+            active_mode,
+            include_suppressed=True,
+            suppressed_only=True,
+        ).subquery()
+        total_groups += int(db.scalar(select(func.count()).select_from(grouped)) or 0)
+    return total_groups
+
+
 def _group_label(mode: DuplicateDetectionMode, signature: str, label_source: str | None) -> str:
     if mode == DuplicateDetectionMode.filehash:
         return label_source or f"{FILE_HASH_ALGORITHM}:{signature[:12]}"
@@ -226,14 +345,48 @@ class DuplicateGroupRow:
     file_count: int
     total_size_bytes: int
     label_source: str | None
+    suppressed: bool = False
 
 
-def _count_groups_for_mode(db: Session, library_id: int, mode: DuplicateDetectionMode) -> int:
-    grouped = _active_signature_statement(library_id, mode).subquery()
+def _count_groups_for_mode(
+    db: Session,
+    library_id: int,
+    mode: DuplicateDetectionMode,
+    *,
+    include_suppressed: bool = False,
+) -> int:
+    grouped = _active_signature_statement(library_id, mode, include_suppressed=include_suppressed).subquery()
     return int(db.scalar(select(func.count()).select_from(grouped)) or 0)
 
 
-def _page_group_rows(db: Session, library_id: int, mode: DuplicateDetectionMode, offset: int, limit: int) -> list[DuplicateGroupRow]:
+def _suppressed_signatures(
+    db: Session,
+    library_id: int,
+    mode: DuplicateDetectionMode,
+    signatures: Sequence[str],
+) -> set[str]:
+    if not signatures:
+        return set()
+    return set(
+        db.execute(
+            select(DuplicateGroupSuppression.signature).where(
+                DuplicateGroupSuppression.library_id == library_id,
+                DuplicateGroupSuppression.mode == mode,
+                DuplicateGroupSuppression.signature.in_(signatures),
+            )
+        ).scalars()
+    )
+
+
+def _page_group_rows(
+    db: Session,
+    library_id: int,
+    mode: DuplicateDetectionMode,
+    offset: int,
+    limit: int,
+    *,
+    include_suppressed: bool = False,
+) -> list[DuplicateGroupRow]:
     if limit <= 0:
         return []
 
@@ -242,12 +395,16 @@ def _page_group_rows(db: Session, library_id: int, mode: DuplicateDetectionMode,
     remaining_limit = limit
 
     for active_mode in get_active_duplicate_detection_modes(mode):
-        group_count = _count_groups_for_mode(db, library_id, active_mode)
+        group_count = _count_groups_for_mode(db, library_id, active_mode, include_suppressed=include_suppressed)
         if remaining_offset >= group_count:
             remaining_offset -= group_count
             continue
 
-        grouped = _active_signature_statement(library_id, active_mode).subquery()
+        grouped = _active_signature_statement(
+            library_id,
+            active_mode,
+            include_suppressed=include_suppressed,
+        ).subquery()
         result_rows = db.execute(
             select(
                 grouped.c.signature,
@@ -259,6 +416,12 @@ def _page_group_rows(db: Session, library_id: int, mode: DuplicateDetectionMode,
             .offset(remaining_offset)
             .limit(remaining_limit)
         ).all()
+        suppressed_signatures = _suppressed_signatures(
+            db,
+            library_id,
+            active_mode,
+            [str(row.signature) for row in result_rows if row.signature is not None],
+        )
         rows.extend(
             DuplicateGroupRow(
                 mode=active_mode,
@@ -266,6 +429,7 @@ def _page_group_rows(db: Session, library_id: int, mode: DuplicateDetectionMode,
                 file_count=int(row.file_count or 0),
                 total_size_bytes=int(row.total_size_bytes or 0),
                 label_source=row.label_source,
+                suppressed=str(row.signature) in suppressed_signatures,
             )
             for row in result_rows
             if row.signature is not None
@@ -342,6 +506,7 @@ def list_library_duplicate_groups(
     *,
     offset: int = 0,
     limit: int = 25,
+    include_suppressed: bool = False,
 ) -> DuplicateGroupPageRead:
     library = db.get(Library, library_id)
     if library is None:
@@ -349,7 +514,15 @@ def list_library_duplicate_groups(
 
     mode = library.duplicate_detection_mode
     total_groups, duplicate_file_count = get_duplicate_group_counts(db, library_id, mode)
-    group_rows = _page_group_rows(db, library_id, mode, offset, limit)
+    suppressed_group_count = get_suppressed_duplicate_group_count(db, library_id, mode)
+    group_rows = _page_group_rows(
+        db,
+        library_id,
+        mode,
+        offset,
+        limit,
+        include_suppressed=include_suppressed,
+    )
     items_by_signature = _group_files_by_signature(db, library_id, group_rows)
 
     items = [
@@ -359,6 +532,7 @@ def list_library_duplicate_groups(
             label=_group_label(row.mode, row.signature, row.label_source),
             file_count=row.file_count,
             total_size_bytes=row.total_size_bytes,
+            suppressed=row.suppressed,
             items=items_by_signature.get((row.mode, row.signature), []),
         )
         for row in group_rows
@@ -367,6 +541,8 @@ def list_library_duplicate_groups(
         mode=mode,
         total_groups=total_groups,
         duplicate_file_count=duplicate_file_count,
+        include_suppressed=include_suppressed,
+        suppressed_group_count=suppressed_group_count,
         offset=offset,
         limit=limit,
         items=items,

--- a/backend/app/services/library_history_service.py
+++ b/backend/app/services/library_history_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import Session
 
 from backend.app.models.entities import Library, LibraryHistory
 from backend.app.schemas.library_history import (
+    DashboardHistoryLibraryRead,
     DashboardHistoryResponse,
     LibraryHistoryNumericSummaryRead,
     LibraryHistoryPointRead,
@@ -483,11 +484,12 @@ def get_dashboard_history(db: Session) -> DashboardHistoryResponse:
         return cached
 
     resolution_categories = _resolution_categories(db)
-    visible_library_ids = db.scalars(
-        select(Library.id)
+    visible_libraries = db.execute(
+        select(Library.id, Library.name)
         .where(Library.show_on_dashboard.is_(True))
         .order_by(Library.id.asc())
     ).all()
+    visible_library_ids = [int(row.id) for row in visible_libraries]
     points_by_day: OrderedDict[str, dict] = OrderedDict()
 
     rows = db.scalars(
@@ -525,6 +527,9 @@ def get_dashboard_history(db: Session) -> DashboardHistoryResponse:
             aggregate_counts = aggregate["category_counts"].setdefault(metric_id, {})
             for value_key, count in counts.items():
                 aggregate_counts[value_key] = aggregate_counts.get(value_key, 0) + count
+        library_counts = aggregate["category_counts"].setdefault("library", {})
+        library_key = str(row.library_id)
+        library_counts[library_key] = library_counts.get(library_key, 0) + metrics.total_files
         for metric_id, distribution in metrics.numeric_distributions.items():
             _add_numeric_distribution(aggregate["numeric_distributions"], metric_id, distribution)
 
@@ -561,6 +566,10 @@ def get_dashboard_history(db: Session) -> DashboardHistoryResponse:
         ],
         points=points,
         visible_library_ids=visible_library_ids,
+        visible_libraries=[
+            DashboardHistoryLibraryRead(id=int(row.id), name=row.name)
+            for row in visible_libraries
+        ],
     )
     stats_cache.set_dashboard_history(cache_key, payload)
     return payload

--- a/desktop/ffprobe-paths.cjs
+++ b/desktop/ffprobe-paths.cjs
@@ -5,10 +5,6 @@ function bundledFfprobeName(platform = process.platform) {
   return platform === "win32" ? "ffprobe.exe" : "ffprobe";
 }
 
-function bundledFfprobeLauncherName(platform = process.platform) {
-  return platform === "linux" ? "ffprobe-medialyze" : bundledFfprobeName(platform);
-}
-
 function normalizeEnvPath(value) {
   if (typeof value !== "string") {
     return null;
@@ -19,54 +15,12 @@ function normalizeEnvPath(value) {
 
 function packagedFfprobeCandidates(resourcesPath, platform = process.platform) {
   const executableName = bundledFfprobeName(platform);
-  const launcherName = bundledFfprobeLauncherName(platform);
-  const names = launcherName === executableName ? [executableName] : [launcherName, executableName];
   return [
-    ...names.map((name) => path.join(resourcesPath, "backend", "ffprobe", name)),
-    ...names.map((name) => path.join(resourcesPath, "backend", "ffprobe", "bin", name)),
-    ...names.map((name) => path.join(resourcesPath, "ffprobe", name)),
-    ...names.map((name) => path.join(resourcesPath, "ffprobe", "bin", name)),
+    path.join(resourcesPath, "backend", "ffprobe", executableName),
+    path.join(resourcesPath, "backend", "ffprobe", "bin", executableName),
+    path.join(resourcesPath, "ffprobe", executableName),
+    path.join(resourcesPath, "ffprobe", "bin", executableName),
   ];
-}
-
-function packagedFfprobeLibraryCandidates(resourcesPath) {
-  return [
-    path.join(resourcesPath, "backend", "ffprobe", "lib"),
-    path.join(resourcesPath, "ffprobe", "lib"),
-  ];
-}
-
-function resolveFfprobeLibraryPath({
-  isPackaged,
-  resourcesPath,
-  platform = process.platform,
-  exists = existsSync,
-} = {}) {
-  if (!isPackaged || platform !== "linux" || !resourcesPath) {
-    return null;
-  }
-
-  for (const candidate of packagedFfprobeLibraryCandidates(resourcesPath)) {
-    if (exists(candidate)) {
-      return candidate;
-    }
-  }
-
-  return null;
-}
-
-function prependLibraryPath(libraryPath, existingValue) {
-  if (!libraryPath) {
-    return existingValue;
-  }
-  return [libraryPath, existingValue].filter(Boolean).join(":");
-}
-
-function isPackagedFfprobePath(candidate, resourcesPath, platform = process.platform) {
-  if (!candidate || !resourcesPath) {
-    return false;
-  }
-  return packagedFfprobeCandidates(resourcesPath, platform).includes(candidate);
 }
 
 function resolveFfprobePath({
@@ -96,48 +50,8 @@ function resolveFfprobePath({
   return "ffprobe";
 }
 
-function resolveFfprobeEnvironment({
-  isPackaged,
-  resourcesPath,
-  env = process.env,
-  platform = process.platform,
-  exists = existsSync,
-} = {}) {
-  const ffprobePath = resolveFfprobePath({
-    isPackaged,
-    resourcesPath,
-    env,
-    platform,
-    exists,
-  });
-  const resolvedEnv = {
-    FFPROBE_PATH: ffprobePath,
-  };
-
-  if (isPackagedFfprobePath(ffprobePath, resourcesPath, platform)) {
-    const libraryPath = resolveFfprobeLibraryPath({
-      isPackaged,
-      resourcesPath,
-      platform,
-      exists,
-    });
-    const ldLibraryPath = prependLibraryPath(libraryPath, env.LD_LIBRARY_PATH);
-    if (ldLibraryPath) {
-      resolvedEnv.LD_LIBRARY_PATH = ldLibraryPath;
-    }
-  }
-
-  return resolvedEnv;
-}
-
 module.exports = {
-  bundledFfprobeLauncherName,
   bundledFfprobeName,
-  isPackagedFfprobePath,
-  packagedFfprobeLibraryCandidates,
   packagedFfprobeCandidates,
-  prependLibraryPath,
-  resolveFfprobeEnvironment,
-  resolveFfprobeLibraryPath,
   resolveFfprobePath,
 };

--- a/desktop/ffprobe-paths.test.cjs
+++ b/desktop/ffprobe-paths.test.cjs
@@ -27,7 +27,7 @@ test("resolveFfprobePath falls back to bundled packaged candidates", () => {
     exists: (candidate) => candidate === candidates[0],
   });
 
-  assert.equal(resolved, "/app/resources/backend/ffprobe/ffprobe");
+  assert.equal(resolved, candidates[0]);
 });
 
 test("resolveFfprobePath keeps an explicit override when packaged candidates are missing", () => {

--- a/desktop/ffprobe-paths.test.cjs
+++ b/desktop/ffprobe-paths.test.cjs
@@ -2,21 +2,9 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 
 const {
-  bundledFfprobeLauncherName,
-  isPackagedFfprobePath,
-  packagedFfprobeLibraryCandidates,
   packagedFfprobeCandidates,
-  prependLibraryPath,
-  resolveFfprobeEnvironment,
-  resolveFfprobeLibraryPath,
   resolveFfprobePath,
 } = require("./ffprobe-paths.cjs");
-
-test("bundledFfprobeLauncherName uses a Linux wrapper", () => {
-  assert.equal(bundledFfprobeLauncherName("linux"), "ffprobe-medialyze");
-  assert.equal(bundledFfprobeLauncherName("darwin"), "ffprobe");
-  assert.equal(bundledFfprobeLauncherName("win32"), "ffprobe.exe");
-});
 
 test("resolveFfprobePath prefers an explicit existing override in packaged mode", () => {
   const resolved = resolveFfprobePath({
@@ -39,7 +27,7 @@ test("resolveFfprobePath falls back to bundled packaged candidates", () => {
     exists: (candidate) => candidate === candidates[0],
   });
 
-  assert.equal(resolved, candidates[0]);
+  assert.equal(resolved, "/app/resources/backend/ffprobe/ffprobe");
 });
 
 test("resolveFfprobePath keeps an explicit override when packaged candidates are missing", () => {
@@ -61,108 +49,4 @@ test("resolveFfprobePath defaults to PATH lookup in development", () => {
   });
 
   assert.equal(resolved, "ffprobe");
-});
-
-test("resolveFfprobeLibraryPath returns packaged Linux ffprobe lib directory", () => {
-  const candidates = packagedFfprobeLibraryCandidates("/app/resources");
-  const resolved = resolveFfprobeLibraryPath({
-    isPackaged: true,
-    resourcesPath: "/app/resources",
-    platform: "linux",
-    exists: (candidate) => candidate === candidates[0],
-  });
-
-  assert.equal(resolved, candidates[0]);
-});
-
-test("resolveFfprobeLibraryPath is disabled outside packaged Linux builds", () => {
-  const resolved = resolveFfprobeLibraryPath({
-    isPackaged: true,
-    resourcesPath: "/app/resources",
-    platform: "darwin",
-    exists: () => true,
-  });
-
-  assert.equal(resolved, null);
-});
-
-test("prependLibraryPath prepends bundled library directory without dropping existing paths", () => {
-  assert.equal(
-    prependLibraryPath("/app/resources/backend/ffprobe/lib", "/usr/local/lib"),
-    "/app/resources/backend/ffprobe/lib:/usr/local/lib"
-  );
-});
-
-test("prependLibraryPath leaves existing value alone when no bundled library path exists", () => {
-  assert.equal(prependLibraryPath(null, "/usr/local/lib"), "/usr/local/lib");
-});
-
-test("isPackagedFfprobePath detects bundled candidates only", () => {
-  const candidates = packagedFfprobeCandidates("/app/resources", "linux");
-
-  assert.equal(
-    isPackagedFfprobePath(candidates[0], "/app/resources", "linux"),
-    true
-  );
-  assert.equal(
-    isPackagedFfprobePath("/usr/local/bin/ffprobe", "/app/resources", "linux"),
-    false
-  );
-});
-
-test("resolveFfprobeEnvironment honors system override without bundled libraries", () => {
-  const resolved = resolveFfprobeEnvironment({
-    isPackaged: true,
-    resourcesPath: "/app/resources",
-    platform: "linux",
-    env: {
-      FFPROBE_PATH: "/usr/local/bin/ffprobe",
-      LD_LIBRARY_PATH: "/usr/local/lib",
-    },
-    exists: (candidate) =>
-      candidate === "/usr/local/bin/ffprobe" ||
-      candidate === "/app/resources/backend/ffprobe/lib",
-  });
-
-  assert.deepEqual(resolved, {
-    FFPROBE_PATH: "/usr/local/bin/ffprobe",
-  });
-});
-
-test("resolveFfprobeEnvironment adds bundled libraries for bundled Linux ffprobe", () => {
-  const ffprobeCandidates = packagedFfprobeCandidates("/app/resources", "linux");
-  const libraryCandidates = packagedFfprobeLibraryCandidates("/app/resources");
-  const resolved = resolveFfprobeEnvironment({
-    isPackaged: true,
-    resourcesPath: "/app/resources",
-    platform: "linux",
-    env: {
-      LD_LIBRARY_PATH: "/usr/local/lib",
-    },
-    exists: (candidate) =>
-      candidate === ffprobeCandidates[0] || candidate === libraryCandidates[0],
-  });
-
-  assert.deepEqual(resolved, {
-    FFPROBE_PATH: ffprobeCandidates[0],
-    LD_LIBRARY_PATH: `${libraryCandidates[0]}:/usr/local/lib`,
-  });
-});
-
-test("resolveFfprobeEnvironment falls back to bundled binary when wrapper is missing", () => {
-  const ffprobeCandidates = packagedFfprobeCandidates("/app/resources", "linux");
-  const libraryCandidates = packagedFfprobeLibraryCandidates("/app/resources");
-  const resolved = resolveFfprobeEnvironment({
-    isPackaged: true,
-    resourcesPath: "/app/resources",
-    platform: "linux",
-    env: {},
-    exists: (candidate) =>
-      candidate === ffprobeCandidates[1] || candidate === libraryCandidates[0],
-  });
-
-  assert.deepEqual(resolved, {
-    FFPROBE_PATH: ffprobeCandidates[1],
-    LD_LIBRARY_PATH: libraryCandidates[0],
-  });
 });

--- a/desktop/main.cjs
+++ b/desktop/main.cjs
@@ -3,9 +3,7 @@ const http = require("node:http");
 const net = require("node:net");
 const path = require("node:path");
 const { spawn } = require("node:child_process");
-const {
-  resolveFfprobeEnvironment,
-} = require("./ffprobe-paths.cjs");
+const { resolveFfprobePath } = require("./ffprobe-paths.cjs");
 
 let mainWindow = null;
 let backendProcess = null;
@@ -129,7 +127,7 @@ function startBackend(port) {
     APP_PORT: String(port),
     CONFIG_PATH: configPath,
     FRONTEND_DIST_PATH: resolveFrontendDistPath(),
-    ...resolveFfprobeEnvironment({
+    FFPROBE_PATH: resolveFfprobePath({
       isPackaged: app.isPackaged,
       resourcesPath: process.resourcesPath,
     }),

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medialyze-desktop",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medialyze-desktop",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "devDependencies": {
         "electron": "^39.8.5",
         "electron-builder": "^26.0.12",

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medialyze-desktop",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medialyze-desktop",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "devDependencies": {
         "electron": "^39.8.5",
         "electron-builder": "^26.0.12",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medialyze-desktop",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "private": true,
   "description": "Desktop packaging for the MediaLyze local media analysis app.",
   "author": "Frederik Emmer",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medialyze-desktop",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "description": "Desktop packaging for the MediaLyze local media analysis app.",
   "author": "Frederik Emmer",

--- a/desktop/scripts/build-backend.mjs
+++ b/desktop/scripts/build-backend.mjs
@@ -1,12 +1,10 @@
 import {
   cpSync,
   existsSync,
-  chmodSync,
   mkdirSync,
   realpathSync,
   rmSync,
   statSync,
-  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,10 +19,6 @@ const specDir = path.join(repoRoot, "dist", "pyinstaller-spec");
 
 export function bundledFfprobeName(platform = process.platform) {
   return platform === "win32" ? "ffprobe.exe" : "ffprobe";
-}
-
-export function bundledFfprobeLauncherName(platform = process.platform) {
-  return platform === "linux" ? "ffprobe-medialyze" : bundledFfprobeName(platform);
 }
 
 function runCommand(command, args, options = {}) {
@@ -148,121 +142,6 @@ export function parseOtoolRpaths(stdout) {
   }
 
   return rpaths;
-}
-
-export function parseLddDependencies(stdout) {
-  return stdout
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => {
-      const linkedMatch = line.match(/^[^\s]+ => (\/[^\s]+) \(/);
-      if (linkedMatch) {
-        return linkedMatch[1];
-      }
-      const directMatch = line.match(/^(\/[^\s]+) \(/);
-      if (directMatch) {
-        return directMatch[1];
-      }
-      return null;
-    })
-    .filter(Boolean);
-}
-
-function defaultInspectElfBinary(binaryPath) {
-  const dependencyResult = runCommand("ldd", [binaryPath]);
-  return {
-    dependencies: parseLddDependencies(dependencyResult.stdout ?? ""),
-  };
-}
-
-function isLinuxRuntimeDependency(candidate, pathLib = path) {
-  const basename = pathLib.basename(candidate);
-  return (
-    basename.startsWith("ld-linux") ||
-    /^lib(c|m|dl|pthread|rt|resolv|nsl|util|gcc_s)\.so/.test(basename)
-  );
-}
-
-export function bundleLinuxFfprobeDependencies(
-  bundleDir,
-  executablePath,
-  {
-    copy = cpSync,
-    exists = existsSync,
-    inspectBinary = defaultInspectElfBinary,
-    mkdir = mkdirSync,
-    pathLib = path,
-    realpath = realpathSync,
-    sourceExecutablePath = executablePath,
-  } = {}
-) {
-  const libDir = pathLib.join(bundleDir, "lib");
-  const pendingBinaries = [sourceExecutablePath];
-  const inspected = new Set();
-  const copiedLibraries = new Map();
-
-  while (pendingBinaries.length > 0) {
-    const sourcePath = pendingBinaries.pop();
-    const realSourcePath = realpath(sourcePath);
-    if (inspected.has(realSourcePath)) {
-      continue;
-    }
-    inspected.add(realSourcePath);
-
-    const inspection = inspectBinary(sourcePath);
-    for (const dependency of inspection.dependencies) {
-      if (isLinuxRuntimeDependency(dependency, pathLib) || !exists(dependency)) {
-        continue;
-      }
-
-      const realDependency = realpath(dependency);
-      if (copiedLibraries.has(realDependency)) {
-        continue;
-      }
-
-      mkdir(libDir, { recursive: true });
-      const bundledDependency = pathLib.join(
-        libDir,
-        pathLib.basename(realDependency)
-      );
-      copy(realDependency, bundledDependency);
-      copiedLibraries.set(realDependency, bundledDependency);
-      pendingBinaries.push(realDependency);
-    }
-  }
-
-  for (const bundledDependency of copiedLibraries.values()) {
-    if (!exists(bundledDependency)) {
-      throw new Error(
-        `Bundled ffprobe dependency missing after copy: ${bundledDependency}`
-      );
-    }
-  }
-}
-
-export function writeLinuxFfprobeLauncher(
-  bundleDir,
-  executableName = bundledFfprobeName("linux"),
-  {
-    chmod = chmodSync,
-    pathLib = path,
-    writeFile = writeFileSync,
-  } = {}
-) {
-  const launcherName = bundledFfprobeLauncherName("linux");
-  const launcherPath = pathLib.join(bundleDir, launcherName);
-  writeFile(
-    launcherPath,
-    `#!/bin/sh
-set -eu
-SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-export LD_LIBRARY_PATH="$SELF_DIR/lib\${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-exec "$SELF_DIR/${executableName}" "$@"
-`
-  );
-  chmod(launcherPath, 0o755);
-  return launcherPath;
 }
 
 function defaultInspectMachOBinary(binaryPath) {
@@ -490,13 +369,6 @@ export function bundleFfprobe(outputPath, options = {}) {
         sourceExecutablePath: path.join(source.sourcePath, source.executableName),
       });
     }
-    if (platform === "linux") {
-      bundleLinuxFfprobeDependencies(targetDir, bundledExecutable, {
-        ...options,
-        sourceExecutablePath: path.join(source.sourcePath, source.executableName),
-      });
-      writeLinuxFfprobeLauncher(targetDir, source.executableName, options);
-    }
     return bundledExecutable;
   }
 
@@ -514,13 +386,6 @@ export function bundleFfprobe(outputPath, options = {}) {
       ...options,
       sourceExecutablePath: sourceExecutable,
     });
-  }
-  if (platform === "linux") {
-    bundleLinuxFfprobeDependencies(targetDir, targetExecutable, {
-      ...options,
-      sourceExecutablePath: sourceExecutable,
-    });
-    writeLinuxFfprobeLauncher(targetDir, source.executableName, options);
   }
   return targetExecutable;
 }

--- a/desktop/scripts/build-backend.test.mjs
+++ b/desktop/scripts/build-backend.test.mjs
@@ -12,16 +12,12 @@ import os from "node:os";
 import path from "node:path";
 
 import {
-  bundleLinuxFfprobeDependencies,
   bundleMacosFfprobeDependencies,
   bundleFfprobe,
-  bundledFfprobeLauncherName,
   bundledFfprobeName,
-  parseLddDependencies,
   parseOtoolDependencies,
   parseOtoolRpaths,
   resolveBundledFfprobeSource,
-  writeLinuxFfprobeLauncher,
 } from "./build-backend.mjs";
 
 function withTempDir(fn) {
@@ -94,63 +90,30 @@ test("bundleFfprobe creates the expected ffprobe folder structure", () => {
   });
 });
 
-test("bundleFfprobe includes Linux ffprobe shared-library dependencies", () => {
+test("bundleFfprobe copies Linux ffprobe without shared libraries or wrapper", () => {
   withTempDir((tempDir) => {
     const sourceBinary = path.join(tempDir, "source", "ffprobe");
-    const sourceLib = path.join(tempDir, "system-lib", "libavdevice.so.60");
     const outputDir = path.join(tempDir, "desktop-backend");
     mkdirSync(path.dirname(sourceBinary), { recursive: true });
-    mkdirSync(path.dirname(sourceLib), { recursive: true });
     mkdirSync(outputDir, { recursive: true });
     writeFileSync(sourceBinary, "ffprobe-binary");
-    writeFileSync(sourceLib, "avdevice");
 
-    bundleFfprobe(outputDir, {
+    const bundledExecutable = bundleFfprobe(outputDir, {
       env: { MEDIALYZE_FFPROBE_DIR: sourceBinary },
       platform: "linux",
       realpath: (candidate) => candidate,
-      inspectBinary: (candidate) => {
-        if (candidate === sourceBinary) {
-          return {
-            dependencies: [sourceLib],
-          };
-        }
-        if (candidate === sourceLib) {
-          return {
-            dependencies: [],
-          };
-        }
-        throw new Error(`Unexpected inspect target: ${candidate}`);
-      },
     });
 
     assert.equal(
-      readFileSync(path.join(outputDir, "ffprobe", "lib", "libavdevice.so.60"), "utf8"),
-      "avdevice"
+      bundledExecutable,
+      path.join(outputDir, "ffprobe", bundledFfprobeName("linux"))
     );
     assert.equal(
-      existsSync(path.join(outputDir, "ffprobe", bundledFfprobeLauncherName("linux"))),
-      true
+      readFileSync(path.join(outputDir, "ffprobe", "ffprobe"), "utf8"),
+      "ffprobe-binary"
     );
-  });
-});
-
-test("writeLinuxFfprobeLauncher writes executable wrapper with bundled library path", () => {
-  withTempDir((tempDir) => {
-    const bundleDir = path.join(tempDir, "ffprobe");
-    mkdirSync(bundleDir, { recursive: true });
-    const chmodCalls = [];
-    const launcherPath = writeLinuxFfprobeLauncher(bundleDir, "ffprobe", {
-      chmod: (...args) => {
-        chmodCalls.push(args);
-      },
-    });
-
-    const content = readFileSync(launcherPath, "utf8");
-    assert.equal(path.basename(launcherPath), bundledFfprobeLauncherName("linux"));
-    assert.match(content, /LD_LIBRARY_PATH="\$SELF_DIR\/lib/);
-    assert.match(content, /exec "\$SELF_DIR\/ffprobe" "\$@"/);
-    assert.deepEqual(chmodCalls, [[launcherPath, 0o755]]);
+    assert.equal(existsSync(path.join(outputDir, "ffprobe", "lib")), false);
+    assert.equal(existsSync(path.join(outputDir, "ffprobe", "ffprobe-medialyze")), false);
   });
 });
 
@@ -179,77 +142,6 @@ Load command 12
 `);
 
   assert.deepEqual(rpaths, ["@loader_path/../lib", "/opt/homebrew/lib"]);
-});
-
-test("parseLddDependencies extracts linked ELF library paths", () => {
-  const dependencies = parseLddDependencies(`linux-vdso.so.1 (0x00007ffc2b1f9000)
-\tlibavdevice.so.60 => /lib/x86_64-linux-gnu/libavdevice.so.60 (0x00007f95aeb00000)
-\tlibmissing.so.1 => not found
-\t/lib64/ld-linux-x86-64.so.2 (0x00007f95b0400000)
-`);
-
-  assert.deepEqual(dependencies, [
-    "/lib/x86_64-linux-gnu/libavdevice.so.60",
-    "/lib64/ld-linux-x86-64.so.2",
-  ]);
-});
-
-test("bundleLinuxFfprobeDependencies copies non-runtime ELF dependencies recursively", () => {
-  const pathLib = path.posix;
-  const bundleDir = "/bundle/ffprobe";
-  const libDir = pathLib.join(bundleDir, "lib");
-  const executablePath = pathLib.join(bundleDir, "ffprobe");
-  const sourceExecutablePath = "/source/ffprobe";
-  const avdevicePath = "/lib/x86_64-linux-gnu/libavdevice.so.60";
-  const avutilPath = "/lib/x86_64-linux-gnu/libavutil.so.58";
-  const libcPath = "/lib/x86_64-linux-gnu/libc.so.6";
-  const loaderPath = "/lib64/ld-linux-x86-64.so.2";
-
-  const directories = new Set([bundleDir, "/source", "/lib/x86_64-linux-gnu", "/lib64"]);
-  const files = new Map([
-    [executablePath, "ffprobe-binary"],
-    [sourceExecutablePath, "ffprobe-source"],
-    [avdevicePath, "avdevice"],
-    [avutilPath, "avutil"],
-    [libcPath, "libc"],
-    [loaderPath, "loader"],
-  ]);
-
-  bundleLinuxFfprobeDependencies(bundleDir, executablePath, {
-    sourceExecutablePath,
-    pathLib,
-    copy: (sourcePath, targetPath) => {
-      files.set(targetPath, files.get(sourcePath) ?? "");
-    },
-    exists: (candidate) => files.has(candidate) || directories.has(candidate),
-    inspectBinary: (candidate) => {
-      if (candidate === sourceExecutablePath) {
-        return {
-          dependencies: [avdevicePath, loaderPath],
-        };
-      }
-      if (candidate === avdevicePath) {
-        return {
-          dependencies: [avutilPath, libcPath],
-        };
-      }
-      if (candidate === avutilPath) {
-        return {
-          dependencies: [libcPath],
-        };
-      }
-      throw new Error(`Unexpected inspect target: ${candidate}`);
-    },
-    mkdir: (directoryPath) => {
-      directories.add(directoryPath);
-    },
-    realpath: (candidate) => candidate,
-  });
-
-  assert.equal(files.get(pathLib.join(libDir, "libavdevice.so.60")), "avdevice");
-  assert.equal(files.get(pathLib.join(libDir, "libavutil.so.58")), "avutil");
-  assert.equal(files.has(pathLib.join(libDir, "libc.so.6")), false);
-  assert.equal(files.has(pathLib.join(libDir, "ld-linux-x86-64.so.2")), false);
 });
 
 test(

--- a/desktop/scripts/build-linux-static-ffprobe.sh
+++ b/desktop/scripts/build-linux-static-ffprobe.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "build-linux-static-ffprobe.sh must run on Linux." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+BUILD_ROOT="${RUNNER_TEMP:-$REPO_ROOT/dist}/medialyze-ffprobe-build"
+OUTPUT_DIR="$REPO_ROOT/dist/ffprobe-bundle"
+
+FFMPEG_VERSION="7.1.1"
+FFMPEG_TARBALL="ffmpeg-${FFMPEG_VERSION}.tar.xz"
+FFMPEG_URL="https://ffmpeg.org/releases/${FFMPEG_TARBALL}"
+FFMPEG_SHA256="733984395e0dbbe5c046abda2dc49a5544e7e0e1e2366bba849222ae9e3a03b1"
+
+rm -rf "$BUILD_ROOT"
+mkdir -p "$BUILD_ROOT" "$OUTPUT_DIR"
+
+cd "$BUILD_ROOT"
+curl -fsSLO "$FFMPEG_URL"
+printf '%s  %s\n' "$FFMPEG_SHA256" "$FFMPEG_TARBALL" | sha256sum -c -
+tar -xf "$FFMPEG_TARBALL"
+
+cd "ffmpeg-${FFMPEG_VERSION}"
+CC=musl-gcc ./configure \
+  --cc=musl-gcc \
+  --extra-ldflags="-static" \
+  --disable-shared \
+  --enable-static \
+  --disable-autodetect \
+  --disable-doc \
+  --disable-debug \
+  --disable-programs \
+  --enable-ffprobe \
+  --disable-ffmpeg \
+  --disable-ffplay \
+  --disable-network
+
+make -j"$(nproc)" ffprobe
+cp ffprobe "$OUTPUT_DIR/ffprobe"
+chmod +x "$OUTPUT_DIR/ffprobe"
+
+"$OUTPUT_DIR/ffprobe" -version >/dev/null
+if readelf -d "$OUTPUT_DIR/ffprobe" | grep -q "(NEEDED)"; then
+  echo "Expected static ffprobe, but readelf reported dynamic NEEDED entries." >&2
+  readelf -d "$OUTPUT_DIR/ffprobe" >&2
+  exit 1
+fi
+

--- a/docs/build_desktop.md
+++ b/docs/build_desktop.md
@@ -111,6 +111,44 @@ Typical output:
 
 - unpacked app directory: `dist/desktop-app/win-unpacked/`
 
+## Linux
+
+Prerequisites:
+
+- Python 3.12
+- Node.js 22
+- build tools for the static `ffprobe` build:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential ca-certificates curl nasm pkg-config xz-utils musl-tools binutils
+```
+
+Build a release AppImage:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev] pyinstaller
+
+cd frontend
+npm ci
+npm run build
+
+cd ..
+desktop/scripts/build-linux-static-ffprobe.sh
+
+cd desktop
+npm ci
+
+MEDIALYZE_FFPROBE_DIR="$(cd ../dist/ffprobe-bundle && pwd)" npm run build:backend
+npm run dist
+```
+
+Output:
+
+- AppImage: `dist/desktop-app/MediaLyze.AppImage`
+
 ## Notes
 
 - `npm run build:backend` creates the packaged Python sidecar in `dist/desktop-backend/`.

--- a/frontend/locales/de/common.json
+++ b/frontend/locales/de/common.json
@@ -477,7 +477,14 @@
       "fileCount": "{{count}} Dateien",
       "searchPlaceholder": "Duplikate durchsuchen",
       "searchLabel": "Duplikate durchsuchen",
-      "clearSearch": "Duplikat-Suche loeschen"
+      "clearSearch": "Duplikat-Suche loeschen",
+      "showSuppressed": "Ausgeblendete anzeigen",
+      "hideSuppressed": "Ausgeblendete ausblenden",
+      "suppressedBadge": "Ausgeblendet",
+      "markNotDuplicate": "Als kein Duplikat markieren",
+      "restoreDuplicate": "Duplikatgruppe wiederherstellen",
+      "suppressFailed": "Die Duplikatgruppe konnte nicht als kein Duplikat markiert werden.",
+      "restoreFailed": "Die Duplikatgruppe konnte nicht wiederhergestellt werden."
     },
     "history": {
       "title": "Mediathekverlauf",

--- a/frontend/locales/de/common.json
+++ b/frontend/locales/de/common.json
@@ -525,6 +525,7 @@
         "average_duration_seconds": "Durchschnittliche Dauer",
         "average_quality_score": "Durchschnittlicher Qualitaets-Score",
         "average_resolution_mp": "Durchschnittliche Aufloesung in MP",
+        "library_mix": "Mediatheken-Mix",
         "container_mix": "Container-Mix",
         "video_codec_mix": "Video-Codec-Mix",
         "hdr_type_mix": "Dynamikumfang-Mix",

--- a/frontend/locales/en/common.json
+++ b/frontend/locales/en/common.json
@@ -477,7 +477,14 @@
       "fileCount": "{{count}} files",
       "searchPlaceholder": "Search duplicates",
       "searchLabel": "Search duplicates",
-      "clearSearch": "Clear duplicate search"
+      "clearSearch": "Clear duplicate search",
+      "showSuppressed": "Show hidden",
+      "hideSuppressed": "Hide hidden",
+      "suppressedBadge": "Hidden",
+      "markNotDuplicate": "Mark as not duplicate",
+      "restoreDuplicate": "Restore duplicate group",
+      "suppressFailed": "Could not mark the duplicate group as not duplicate.",
+      "restoreFailed": "Could not restore the duplicate group."
     },
     "history": {
       "title": "Media library history",

--- a/frontend/locales/en/common.json
+++ b/frontend/locales/en/common.json
@@ -525,6 +525,7 @@
         "average_duration_seconds": "Average duration",
         "average_quality_score": "Average quality score",
         "average_resolution_mp": "Average resolution MP",
+        "library_mix": "Library mix",
         "container_mix": "Container mix",
         "video_codec_mix": "Video codec mix",
         "hdr_type_mix": "Dynamic range mix",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medialyze-frontend",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medialyze-frontend",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "dependencies": {
         "@tanstack/react-virtual": "^3.13.21",
         "echarts": "^6.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medialyze-frontend",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medialyze-frontend",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "dependencies": {
         "@tanstack/react-virtual": "^3.13.21",
         "echarts": "^6.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medialyze-frontend",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medialyze-frontend",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/frontend/src/components/AsyncPanel.tsx
+++ b/frontend/src/components/AsyncPanel.tsx
@@ -20,6 +20,7 @@ type AsyncPanelProps = {
     collapsed: boolean;
     onToggle: () => void;
     bodyId?: string;
+    disabled?: boolean;
   };
   children: ReactNode;
 };
@@ -43,6 +44,7 @@ export function AsyncPanel({
   const generatedBodyId = useId();
   const bodyId = collapseState?.bodyId ?? `async-panel-body-${generatedBodyId}`;
   const isCollapsed = collapseState?.collapsed ?? false;
+  const collapseDisabled = collapseState?.disabled ?? false;
   const ToggleIcon = isCollapsed ? ChevronRight : ChevronDown;
   const hasHeaderLead = Boolean(collapseState || title || titleAddon || subtitle || subtitleAddon);
 
@@ -60,29 +62,32 @@ export function AsyncPanel({
                       className={`async-panel-toggle${collapseActions ? " has-collapse-actions" : ""}`}
                       aria-expanded={!isCollapsed}
                       aria-controls={bodyId}
+                      disabled={collapseDisabled}
                       onClick={collapseState.onToggle}
                     >
                       <span>{title}</span>
-                      {!collapseActions ? <ToggleIcon aria-hidden="true" className="nav-icon" /> : null}
+                      {!collapseActions && !collapseDisabled ? <ToggleIcon aria-hidden="true" className="nav-icon" /> : null}
                     </button>
                   </h2>
                   {collapseActions ? (
                     <div className="async-panel-toggle-actions">
                       {collapseActions}
-                      <button
-                        type="button"
-                        className={`secondary icon-only-button async-panel-toggle-icon-button${collapseButtonClassName ? ` ${collapseButtonClassName}` : ""}`}
-                        aria-label={
-                          isCollapsed
-                            ? t("panel.expandAria", { title })
-                            : t("panel.collapseAria", { title })
-                        }
-                        aria-expanded={!isCollapsed}
-                        aria-controls={bodyId}
-                        onClick={collapseState.onToggle}
-                      >
-                        <ToggleIcon aria-hidden="true" className="nav-icon" />
-                      </button>
+                      {!collapseDisabled ? (
+                        <button
+                          type="button"
+                          className={`secondary icon-only-button async-panel-toggle-icon-button${collapseButtonClassName ? ` ${collapseButtonClassName}` : ""}`}
+                          aria-label={
+                            isCollapsed
+                              ? t("panel.expandAria", { title })
+                              : t("panel.collapseAria", { title })
+                          }
+                          aria-expanded={!isCollapsed}
+                          aria-controls={bodyId}
+                          onClick={collapseState.onToggle}
+                        >
+                          <ToggleIcon aria-hidden="true" className="nav-icon" />
+                        </button>
+                      ) : null}
                     </div>
                   ) : null}
                 </>

--- a/frontend/src/components/HistoryTrendChart.test.tsx
+++ b/frontend/src/components/HistoryTrendChart.test.tsx
@@ -12,6 +12,7 @@ const historyPoints: LibraryHistoryPoint[] = [
     trend_metrics: {
       total_files: 10,
       resolution_counts: { "4k": 2, "1080p": 8 },
+      category_counts: { library: { "1": 4, "2": 6 } },
       average_bitrate: null,
       average_audio_bitrate: null,
       average_duration_seconds: null,
@@ -32,6 +33,7 @@ const historyPoints: LibraryHistoryPoint[] = [
     trend_metrics: {
       total_files: 12,
       resolution_counts: { "4k": 3, "1080p": 9 },
+      category_counts: { library: { "1": 5, "2": 7 } },
       average_bitrate: null,
       average_audio_bitrate: null,
       average_duration_seconds: null,
@@ -88,5 +90,25 @@ describe("HistoryTrendChart", () => {
     );
 
     expect(renderedYAxis()).not.toHaveProperty("max");
+  });
+
+  it("uses dashboard library names for library mix series", () => {
+    render(
+      <HistoryTrendChart
+        points={historyPoints}
+        resolutionCategories={[]}
+        libraryCategories={[
+          { id: 1, name: "Movies" },
+          { id: 2, name: "Shows" },
+        ]}
+        metricId="library_mix"
+        displayMode="count"
+      />,
+    );
+
+    expect(JSON.parse(screen.getByTestId("echarts-react").getAttribute("data-series-names") ?? "[]")).toEqual([
+      "Movies",
+      "Shows",
+    ]);
   });
 });

--- a/frontend/src/components/HistoryTrendChart.tsx
+++ b/frontend/src/components/HistoryTrendChart.tsx
@@ -6,7 +6,7 @@ import { GridComponent, LegendComponent, TooltipComponent } from "echarts/compon
 import { CanvasRenderer } from "echarts/renderers";
 import { useTranslation } from "react-i18next";
 
-import type { LibraryHistoryPoint, LibraryHistoryResolutionCategory } from "../lib/api";
+import type { DashboardHistoryLibrary, LibraryHistoryPoint, LibraryHistoryResolutionCategory } from "../lib/api";
 import {
   formatHistoryMetricValue,
   getHistoryMetricDefinition,
@@ -20,6 +20,7 @@ echarts.use([LineChart, GridComponent, LegendComponent, TooltipComponent, Canvas
 type HistoryTrendChartProps = {
   points: LibraryHistoryPoint[];
   resolutionCategories: LibraryHistoryResolutionCategory[];
+  libraryCategories?: DashboardHistoryLibrary[];
   metricId: LibraryHistoryMetricId;
   displayMode?: HistoryMetricDisplayMode;
   inDepthDolbyVisionProfiles?: boolean;
@@ -63,6 +64,7 @@ function categorySeriesKeys(
   points: LibraryHistoryPoint[],
   categoryKey: string,
   resolutionCategories: LibraryHistoryResolutionCategory[],
+  libraryCategories: DashboardHistoryLibrary[],
   inDepthDolbyVisionProfiles: boolean,
 ): string[] {
   const keys = new Set<string>();
@@ -75,6 +77,12 @@ function categorySeriesKeys(
     return [
       ...resolutionCategories.map((category) => category.id).filter((id) => keys.has(id)),
       ...[...keys].filter((id) => !resolutionCategories.some((category) => category.id === id)).sort(),
+    ];
+  }
+  if (categoryKey === "library") {
+    return [
+      ...libraryCategories.map((library) => String(library.id)).filter((id) => keys.has(id)),
+      ...[...keys].filter((id) => !libraryCategories.some((library) => String(library.id) === id)).sort(),
     ];
   }
   return [...keys].sort((left, right) => {
@@ -116,6 +124,7 @@ function findDistributionBin(point: LibraryHistoryPoint, distributionKey: string
 function HistoryTrendChartComponent({
   points,
   resolutionCategories,
+  libraryCategories = [],
   metricId,
   displayMode = "count",
   inDepthDolbyVisionProfiles = false,
@@ -203,6 +212,7 @@ function HistoryTrendChartComponent({
           points,
           metric.categoryKey,
           resolutionCategories,
+          libraryCategories,
           inDepthDolbyVisionProfiles,
         );
         return {
@@ -256,7 +266,7 @@ function HistoryTrendChartComponent({
             splitLine: { lineStyle: { color: lineColor, opacity: 0.08 } },
           },
           series: seriesKeys.map((key) => ({
-            name: metric.formatCategory(key, resolutionCategories, { inDepthDolbyVisionProfiles }),
+            name: metric.formatCategory(key, resolutionCategories, { inDepthDolbyVisionProfiles }, libraryCategories),
             type: "line",
             stack: metric.id,
             showSymbol: points.length <= 1,
@@ -353,6 +363,7 @@ function HistoryTrendChartComponent({
       points,
       metric.categoryKey,
       resolutionCategories,
+      libraryCategories,
       inDepthDolbyVisionProfiles,
     );
     return {
@@ -406,7 +417,7 @@ function HistoryTrendChartComponent({
         splitLine: { lineStyle: { color: lineColor, opacity: 0.08 } },
       },
       series: seriesKeys.map((key) => ({
-        name: metric.formatCategory(key, resolutionCategories, { inDepthDolbyVisionProfiles }),
+        name: metric.formatCategory(key, resolutionCategories, { inDepthDolbyVisionProfiles }, libraryCategories),
         type: "line",
         stack: metric.id,
         showSymbol: points.length <= 1,
@@ -433,6 +444,7 @@ function HistoryTrendChartComponent({
     lineColor,
     metric,
     points,
+    libraryCategories,
     resolutionCategories,
     t,
     tooltipBase,
@@ -455,6 +467,7 @@ export const HistoryTrendChart = memo(
   (previousProps, nextProps) =>
     previousProps.points === nextProps.points &&
     previousProps.resolutionCategories === nextProps.resolutionCategories &&
+    previousProps.libraryCategories === nextProps.libraryCategories &&
     previousProps.metricId === nextProps.metricId &&
     previousProps.displayMode === nextProps.displayMode &&
     previousProps.inDepthDolbyVisionProfiles === nextProps.inDepthDolbyVisionProfiles &&

--- a/frontend/src/components/LibraryHistoryPanel.tsx
+++ b/frontend/src/components/LibraryHistoryPanel.tsx
@@ -38,6 +38,7 @@ type LibraryHistoryPanelProps = {
   rangeStorageKey?: string;
   bodyId?: string;
   inDepthDolbyVisionProfiles?: boolean;
+  showLibraryMix?: boolean;
 };
 
 const HISTORY_GROUP_ICONS = {
@@ -203,6 +204,7 @@ export function LibraryHistoryPanel({
   rangeStorageKey = DEFAULT_HISTORY_RANGE_STORAGE_KEY,
   bodyId = "library-history-panel-body",
   inDepthDolbyVisionProfiles = false,
+  showLibraryMix = false,
 }: LibraryHistoryPanelProps) {
   const { t, i18n } = useTranslation();
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -230,6 +232,11 @@ export function LibraryHistoryPanel({
     () => getHistoryMetricDefinition(selectedMetric),
     [selectedMetric],
   );
+  const availableMetricDefinitions = useMemo(
+    () =>
+      HISTORY_METRIC_DEFINITIONS.filter((definition) => showLibraryMix || definition.id !== "library_mix"),
+    [showLibraryMix],
+  );
   const SelectedMetricIcon = HISTORY_GROUP_ICONS[selectedMetricDefinition.group];
   const resolutionCategories = useMemo(
     () =>
@@ -242,6 +249,9 @@ export function LibraryHistoryPanel({
       })),
     [currentResolutionCategoryIdSet, history?.resolution_categories, t],
   );
+  const libraryCategories = "visible_libraries" in (history ?? {})
+    ? (history as DashboardHistoryResponse).visible_libraries ?? []
+    : [];
   const filteredHistoryPoints = useMemo(
     () => filterHistoryPoints(history?.points ?? [], rangeSelection),
     [history?.points, rangeSelection],
@@ -597,7 +607,7 @@ export function LibraryHistoryPanel({
                 >
                   {HISTORY_METRIC_GROUPS.map((group) => {
                     const GroupIcon = HISTORY_GROUP_ICONS[group.id];
-                    const metrics = HISTORY_METRIC_DEFINITIONS.filter((definition) => definition.group === group.id);
+                    const metrics = availableMetricDefinitions.filter((definition) => definition.group === group.id);
                     return (
                       <div key={group.id} className="library-history-picker-group">
                         <div className="library-history-picker-group-label">
@@ -647,6 +657,7 @@ export function LibraryHistoryPanel({
           <HistoryTrendChart
             points={filteredHistoryPoints}
             resolutionCategories={resolutionCategories}
+            libraryCategories={libraryCategories}
             metricId={selectedMetric}
             displayMode={displayMode}
             inDepthDolbyVisionProfiles={inDepthDolbyVisionProfiles}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -764,6 +764,7 @@ export type DuplicateGroup = {
   label: string;
   file_count: number;
   total_size_bytes: number;
+  suppressed: boolean;
   items: DuplicateGroupFile[];
 };
 
@@ -771,9 +772,16 @@ export type DuplicateGroupPage = {
   mode: DuplicateDetectionMode;
   total_groups: number;
   duplicate_file_count: number;
+  include_suppressed: boolean;
+  suppressed_group_count: number;
   offset: number;
   limit: number;
   items: DuplicateGroup[];
+};
+
+export type DuplicateSuppressionPayload = {
+  mode: Exclude<DuplicateDetectionMode, "off" | "both">;
+  signature: string;
 };
 
 export type ScanCancelResponse = {
@@ -981,7 +989,7 @@ export const api = {
     ),
   libraryDuplicates: (
     id: string | number,
-    params?: { offset?: number; limit?: number; signal?: AbortSignal },
+    params?: { offset?: number; limit?: number; includeSuppressed?: boolean; signal?: AbortSignal },
   ) => {
     const searchParams = new URLSearchParams();
     if (params?.offset !== undefined) {
@@ -990,9 +998,25 @@ export const api = {
     if (params?.limit !== undefined) {
       searchParams.set("limit", String(params.limit));
     }
+    if (params?.includeSuppressed !== undefined) {
+      searchParams.set("include_suppressed", params.includeSuppressed ? "true" : "false");
+    }
     const query = searchParams.toString();
     return request<DuplicateGroupPage>(`/libraries/${id}/duplicates${query ? `?${query}` : ""}`, {
       signal: params?.signal,
+    });
+  },
+  suppressDuplicateGroup: (id: string | number, payload: DuplicateSuppressionPayload) =>
+    request<void>(`/libraries/${id}/duplicates/suppressions`, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    }),
+  unsuppressDuplicateGroup: (id: string | number, payload: DuplicateSuppressionPayload) => {
+    const searchParams = new URLSearchParams();
+    searchParams.set("mode", payload.mode);
+    searchParams.set("signature", payload.signature);
+    return request<void>(`/libraries/${id}/duplicates/suppressions?${searchParams.toString()}`, {
+      method: "DELETE",
     });
   },
   libraryFiles: (id: string | number, params?: LibraryFilesRequestParams) =>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -124,6 +124,11 @@ export type LibraryHistoryResolutionCategory = {
   label: string;
 };
 
+export type DashboardHistoryLibrary = {
+  id: number;
+  name: string;
+};
+
 export type LibraryHistoryResponse = {
   generated_at: string;
   library_id: number;
@@ -140,6 +145,7 @@ export type DashboardHistoryResponse = {
   resolution_categories: LibraryHistoryResolutionCategory[];
   points: LibraryHistoryPoint[];
   visible_library_ids: number[];
+  visible_libraries: DashboardHistoryLibrary[];
 };
 
 export type QualityCategoryConfig = {

--- a/frontend/src/lib/history-metrics.test.ts
+++ b/frontend/src/lib/history-metrics.test.ts
@@ -11,6 +11,7 @@ describe("history metrics", () => {
   it("groups summary, category, and distribution metrics", () => {
     expect(HISTORY_METRIC_GROUPS.map((group) => group.id)).toEqual(["summary", "category", "distribution"]);
     expect(HISTORY_METRIC_DEFINITIONS.some((definition) => definition.id === "average_quality_score")).toBe(true);
+    expect(HISTORY_METRIC_DEFINITIONS.some((definition) => definition.id === "library_mix")).toBe(true);
     expect(HISTORY_METRIC_DEFINITIONS.some((definition) => definition.id === "container_mix")).toBe(true);
     expect(HISTORY_METRIC_DEFINITIONS.some((definition) => definition.id === "resolution_distribution")).toBe(true);
     expect(HISTORY_METRIC_DEFINITIONS.some((definition) => definition.id === "resolution_mp_distribution")).toBe(true);
@@ -21,6 +22,7 @@ describe("history metrics", () => {
 
   it("validates stored metric ids", () => {
     expect(isLibraryHistoryMetricId("average_quality_score")).toBe(true);
+    expect(isLibraryHistoryMetricId("library_mix")).toBe(true);
     expect(isLibraryHistoryMetricId("resolution_distribution")).toBe(true);
     expect(isLibraryHistoryMetricId("quality_score_distribution")).toBe(true);
     expect(isLibraryHistoryMetricId("ready_files")).toBe(false);

--- a/frontend/src/lib/history-metrics.ts
+++ b/frontend/src/lib/history-metrics.ts
@@ -1,4 +1,5 @@
 import type {
+  DashboardHistoryLibrary,
   LibraryHistoryResolutionCategory,
   LibraryHistoryTrendMetrics,
   NumericDistributionBin,
@@ -22,6 +23,7 @@ export type LibraryHistoryMetricId =
   | "average_audio_bitrate"
   | "average_quality_score"
   | "average_resolution_mp"
+  | "library_mix"
   | "resolution_mix"
   | "container_mix"
   | "video_codec_mix"
@@ -58,6 +60,7 @@ export type HistoryMetricDefinition =
         value: string,
         resolutionCategories: LibraryHistoryResolutionCategory[],
         options?: HdrDisplayOptions,
+        libraryCategories?: DashboardHistoryLibrary[],
       ) => string;
     }
   | {
@@ -76,6 +79,7 @@ export type HistoryMetricDefinition =
         value: string,
         resolutionCategories: LibraryHistoryResolutionCategory[],
         options?: HdrDisplayOptions,
+        libraryCategories?: DashboardHistoryLibrary[],
       ) => string;
     };
 
@@ -97,6 +101,19 @@ function formatResolutionCategory(value: string, resolutionCategories: LibraryHi
 
 function formatPlain(value: string): string {
   return value || "unknown";
+}
+
+function formatLibraryCategory(
+  value: string,
+  _resolutionCategories: LibraryHistoryResolutionCategory[],
+  _options?: HdrDisplayOptions,
+  libraryCategories: DashboardHistoryLibrary[] = [],
+): string {
+  const libraryId = Number(value);
+  if (!Number.isFinite(libraryId)) {
+    return value;
+  }
+  return libraryCategories.find((library) => library.id === libraryId)?.name ?? value;
 }
 
 function formatResolutionMpBin(bin: NumericDistributionBin): string {
@@ -175,6 +192,13 @@ export const HISTORY_METRIC_DEFINITIONS: HistoryMetricDefinition[] = [
     labelKey: "libraryDetail.history.metrics.average_resolution_mp",
     valueKind: "megapixels",
     value: (metrics) => numericAverage(metrics, "resolution_mp"),
+  },
+  {
+    id: "library_mix",
+    group: "category",
+    labelKey: "libraryDetail.history.metrics.library_mix",
+    categoryKey: "library",
+    formatCategory: formatLibraryCategory,
   },
   {
     id: "resolution_mix",

--- a/frontend/src/medialyze.css
+++ b/frontend/src/medialyze.css
@@ -2400,12 +2400,47 @@ html[data-theme="dark"] .comparison-chart-renderer-option.active {
   gap: 12px;
 }
 
+.duplicate-group-card.is-suppressed {
+  border-color: rgba(31, 28, 22, 0.16);
+  background: rgba(31, 28, 22, 0.035);
+}
+
 .duplicate-group-summary {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 12px;
   flex-wrap: wrap;
+}
+
+.duplicate-group-summary-main {
+  display: grid;
+  min-width: 0;
+  gap: 8px;
+  flex: 1 1 18rem;
+}
+
+.duplicate-group-action {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  border: 1px solid rgba(31, 28, 22, 0.12);
+  background: rgba(255, 255, 255, 0.82);
+  color: var(--muted);
+  box-shadow: none;
+}
+
+.duplicate-group-action:hover,
+.duplicate-group-action:focus-visible {
+  color: var(--ink);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: none;
+  transform: none;
+}
+
+.duplicate-group-action:disabled {
+  cursor: wait;
+  opacity: 0.55;
 }
 
 .duplicate-group-items-scroll {
@@ -3461,7 +3496,7 @@ html[data-theme="dark"] .file-history-old-value {
 .duplicate-panel-title-actions {
   display: flex;
   align-items: center;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   gap: 10px;
   min-width: 0;
 }
@@ -3472,6 +3507,28 @@ html[data-theme="dark"] .file-history-old-value {
 
 .duplicate-panel-title-actions .duplicate-search-layout {
   margin-left: 0;
+}
+
+.duplicate-suppressed-toggle {
+  min-height: 29px;
+  padding: 0 10px;
+  border: 1px solid rgba(31, 28, 22, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.82);
+  color: var(--muted);
+  box-shadow: none;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.duplicate-suppressed-toggle:hover,
+.duplicate-suppressed-toggle:focus-visible {
+  color: var(--ink);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: none;
+  transform: none;
 }
 
 .search-filter-picker {

--- a/frontend/src/medialyze.css
+++ b/frontend/src/medialyze.css
@@ -618,6 +618,14 @@
   overflow: hidden;
 }
 
+.library-layout-panel-duplicates .panel-header {
+  margin-bottom: 6px;
+}
+
+.library-layout-panel-duplicates .async-panel-toggle-actions {
+  gap: 4px;
+}
+
 .library-layout-panel-history .library-history-chart-shell {
   height: 100%;
   min-height: 0;
@@ -2397,7 +2405,7 @@ html[data-theme="dark"] .comparison-chart-renderer-option.active {
 
 .duplicate-group-card {
   display: grid;
-  gap: 12px;
+  gap: 6px;
 }
 
 .duplicate-group-card.is-suppressed {
@@ -3490,14 +3498,14 @@ html[data-theme="dark"] .file-history-old-value {
 }
 
 .duplicate-search-layout {
-  --search-control-width: clamp(15rem, 30vw, 24rem);
+  --search-control-width: clamp(15rem, 28vw, 24rem);
 }
 
 .duplicate-panel-title-actions {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 10px;
+  flex-wrap: nowrap;
+  gap: 8px;
   min-width: 0;
 }
 
@@ -3507,6 +3515,8 @@ html[data-theme="dark"] .file-history-old-value {
 
 .duplicate-panel-title-actions .duplicate-search-layout {
   margin-left: 0;
+  flex: 0 1 var(--search-control-width);
+  width: min(100%, var(--search-control-width));
 }
 
 .duplicate-suppressed-toggle {

--- a/frontend/src/pages/DashboardPage.test.tsx
+++ b/frontend/src/pages/DashboardPage.test.tsx
@@ -162,6 +162,10 @@ function createDashboardHistory(): DashboardHistoryResponse {
     oldest_snapshot_day: "2026-04-17",
     newest_snapshot_day: "2026-04-18",
     visible_library_ids: [1, 2],
+    visible_libraries: [
+      { id: 1, name: "Movies" },
+      { id: 2, name: "Shows" },
+    ],
     resolution_categories: [
       { id: "4k", label: "4k" },
       { id: "1080p", label: "1080p" },
@@ -172,6 +176,7 @@ function createDashboardHistory(): DashboardHistoryResponse {
         trend_metrics: {
           total_files: 8,
           resolution_counts: { "4k": 3, "1080p": 5 },
+          category_counts: { library: { "1": 3, "2": 5 } },
           average_bitrate: 8_000_000,
           average_audio_bitrate: 512_000,
           average_duration_seconds: 4_200,
@@ -183,6 +188,7 @@ function createDashboardHistory(): DashboardHistoryResponse {
         trend_metrics: {
           total_files: 10,
           resolution_counts: { "4k": 4, "1080p": 6 },
+          category_counts: { library: { "1": 4, "2": 6 } },
           average_bitrate: 8_500_000,
           average_audio_bitrate: 576_000,
           average_duration_seconds: 4_500,
@@ -494,6 +500,8 @@ describe("DashboardPage", () => {
     expect(historyToggle).toBeInTheDocument();
     expect(historyToggle.closest(".statistic-layout-panel-shell")).not.toBeNull();
     expect(screen.getByLabelText("Select history metric")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Select history metric"));
+    expect(screen.getByRole("menuitemradio", { name: "Library mix" })).toBeInTheDocument();
     expect(screen.queryByText("Daily trend snapshots from finished scans")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -657,6 +657,7 @@ export function DashboardPage() {
                   rangeStorageKey={DASHBOARD_HISTORY_RANGE_STORAGE_KEY}
                   bodyId="dashboard-history-panel-body"
                   inDepthDolbyVisionProfiles={inDepthDolbyVisionProfiles}
+                  showLibraryMix
                 />
               );
             } else if (panel.definition.statisticDefinition.panelKind === "comparison") {

--- a/frontend/src/pages/LibraryDetailPage.test.tsx
+++ b/frontend/src/pages/LibraryDetailPage.test.tsx
@@ -1533,15 +1533,17 @@ describe("LibraryDetailPage", () => {
 
     renderPage(libraryId);
 
-    expect(await screen.findByRole("button", { name: "Duplications" })).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Duplications" }));
-    expect(await screen.findByText("No duplicate groups found yet.")).toBeInTheDocument();
+    const duplicatesToggle = await screen.findByRole("button", { name: "Duplications" });
+    expect(duplicatesToggle).toBeDisabled();
+    expect(screen.queryByText("No duplicate groups found yet.")).not.toBeInTheDocument();
+    expect(screen.queryByRole("searchbox", { name: "Search duplicates" })).not.toBeInTheDocument();
     await waitFor(() => expect(api.activeScanJobs).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(libraryDuplicatesSpy).toHaveBeenCalledTimes(1));
 
     fireEvent.focus(window);
 
     await waitFor(() => expect(libraryDuplicatesSpy.mock.calls.length).toBeGreaterThanOrEqual(2));
+    fireEvent.click(screen.getByRole("button", { name: "Duplications" }));
     expect((await screen.findAllByText("episode-01-copy.mkv")).length).toBeGreaterThan(0);
   });
 

--- a/frontend/src/pages/LibraryDetailPage.test.tsx
+++ b/frontend/src/pages/LibraryDetailPage.test.tsx
@@ -69,6 +69,8 @@ function createDuplicateGroupPage(overrides: Partial<DuplicateGroupPage> = {}): 
     mode: "filename",
     total_groups: 1,
     duplicate_file_count: 2,
+    include_suppressed: false,
+    suppressed_group_count: 0,
     offset: 0,
     limit: 25,
     items: [
@@ -78,6 +80,7 @@ function createDuplicateGroupPage(overrides: Partial<DuplicateGroupPage> = {}): 
         label: "episode 01",
         file_count: 2,
         total_size_bytes: 2048,
+        suppressed: false,
         items: [
           { id: 1, relative_path: "episode-01.mkv", filename: "episode-01.mkv", size_bytes: 1024 },
           { id: 2, relative_path: "episode-01-copy.mkv", filename: "episode-01-copy.mkv", size_bytes: 1024 },
@@ -569,6 +572,8 @@ beforeEach(() => {
   vi.spyOn(api, "libraryComparison").mockResolvedValue(createComparisonResponse());
   vi.spyOn(api, "libraryHistory").mockResolvedValue(createLibraryHistoryResponse());
   vi.spyOn(api, "libraryDuplicates").mockResolvedValue(createDuplicateGroupPage());
+  vi.spyOn(api, "suppressDuplicateGroup").mockResolvedValue(undefined);
+  vi.spyOn(api, "unsuppressDuplicateGroup").mockResolvedValue(undefined);
   vi.spyOn(api, "libraryGroupedFiles").mockResolvedValue({ total: 0, offset: 0, limit: 200, next_cursor: null, has_more: false, items: [] });
   vi.spyOn(api, "librarySeriesGroupedDetail").mockResolvedValue({
     id: 0,
@@ -1140,6 +1145,7 @@ describe("LibraryDetailPage", () => {
             label: "episode 01",
             file_count: 4,
             total_size_bytes: 4096,
+            suppressed: false,
             items: [
               { id: 1, relative_path: "episode-01.mkv", filename: "episode-01.mkv", size_bytes: 1024 },
               { id: 2, relative_path: "episode-01-copy.mkv", filename: "episode-01-copy.mkv", size_bytes: 1024 },
@@ -1159,6 +1165,75 @@ describe("LibraryDetailPage", () => {
     const variantsList = container.querySelector(".duplicate-group-items-scroll");
     expect(variantsList).not.toBeNull();
     expect(variantsList).toHaveClass("scan-log-path-list");
+  });
+
+  it("marks duplicate groups as not duplicate and reloads the panel", async () => {
+    const libraryId = 124;
+    mockAppSettings({ feature_flags: { show_analyzed_files_csv_export: true } });
+    vi.spyOn(api, "librarySummary").mockResolvedValue(createLibrarySummary(libraryId));
+    vi.spyOn(api, "libraryStatistics").mockResolvedValue(createLibraryStatistics());
+    const libraryDuplicatesSpy = vi.spyOn(api, "libraryDuplicates").mockResolvedValue(createDuplicateGroupPage());
+    const suppressSpy = vi.spyOn(api, "suppressDuplicateGroup").mockResolvedValue(undefined);
+    vi.spyOn(api, "libraryFiles").mockResolvedValue(createFilesPage(libraryId));
+
+    renderPage(libraryId);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Duplications" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Mark as not duplicate" }));
+
+    await waitFor(() => {
+      expect(suppressSpy).toHaveBeenCalledWith(String(libraryId), { mode: "filename", signature: "episode 01" });
+    });
+    await waitFor(() => expect(libraryDuplicatesSpy.mock.calls.length).toBeGreaterThanOrEqual(2));
+  });
+
+  it("shows hidden duplicate groups and restores them", async () => {
+    const libraryId = 125;
+    mockAppSettings({ feature_flags: { show_analyzed_files_csv_export: true } });
+    vi.spyOn(api, "librarySummary").mockResolvedValue(createLibrarySummary(libraryId));
+    vi.spyOn(api, "libraryStatistics").mockResolvedValue(createLibraryStatistics());
+    const hiddenPage = createDuplicateGroupPage({
+      total_groups: 0,
+      duplicate_file_count: 0,
+      include_suppressed: true,
+      suppressed_group_count: 1,
+      items: [
+        {
+          mode: "filename",
+          signature: "episode 01",
+          label: "episode 01",
+          file_count: 2,
+          total_size_bytes: 2048,
+          suppressed: true,
+          items: [
+            { id: 1, relative_path: "episode-01.mkv", filename: "episode-01.mkv", size_bytes: 1024 },
+            { id: 2, relative_path: "episode-01-copy.mkv", filename: "episode-01-copy.mkv", size_bytes: 1024 },
+          ],
+        },
+      ],
+    });
+    const libraryDuplicatesSpy = vi
+      .spyOn(api, "libraryDuplicates")
+      .mockResolvedValueOnce(createDuplicateGroupPage({ total_groups: 0, duplicate_file_count: 0, suppressed_group_count: 1, items: [] }))
+      .mockResolvedValue(hiddenPage);
+    const restoreSpy = vi.spyOn(api, "unsuppressDuplicateGroup").mockResolvedValue(undefined);
+    vi.spyOn(api, "libraryFiles").mockResolvedValue(createFilesPage(libraryId));
+
+    renderPage(libraryId);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Duplications" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Show hidden" }));
+
+    expect(await screen.findByText("Hidden")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Restore duplicate group" }));
+
+    await waitFor(() => {
+      expect(restoreSpy).toHaveBeenCalledWith(String(libraryId), { mode: "filename", signature: "episode 01" });
+    });
+    expect(libraryDuplicatesSpy).toHaveBeenCalledWith(
+      String(libraryId),
+      expect.objectContaining({ includeSuppressed: true }),
+    );
   });
 
   it("hides the score meter when the feature flag is enabled", async () => {
@@ -1326,6 +1401,7 @@ describe("LibraryDetailPage", () => {
             label: "episode 01",
             file_count: 2,
             total_size_bytes: 2048,
+            suppressed: false,
             items: [
               { id: 1, relative_path: "episode-01.mkv", filename: "episode-01.mkv", size_bytes: 1024 },
               { id: 2, relative_path: "episode-01-copy.mkv", filename: "episode-01-copy.mkv", size_bytes: 1024 },
@@ -1337,6 +1413,7 @@ describe("LibraryDetailPage", () => {
             label: "bonus-scene.mkv",
             file_count: 2,
             total_size_bytes: 2048,
+            suppressed: false,
             items: [
               { id: 3, relative_path: "bonus-scene.mkv", filename: "bonus-scene.mkv", size_bytes: 1024 },
               { id: 4, relative_path: "bonus-scene-copy.mkv", filename: "bonus-scene-copy.mkv", size_bytes: 1024 },

--- a/frontend/src/pages/LibraryDetailPage.tsx
+++ b/frontend/src/pages/LibraryDetailPage.tsx
@@ -2,6 +2,7 @@ import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   ChevronDown,
   ChevronRight,
+  EyeOff,
   PanelBottomClose,
   PanelLeftClose,
   PanelRightClose,
@@ -9,6 +10,7 @@ import {
   Plus,
   Search,
   Trash2,
+  Undo2,
   X,
 } from "lucide-react";
 import type { CSSProperties, InputHTMLAttributes, PointerEvent as ReactPointerEvent, ReactNode } from "react";
@@ -1298,6 +1300,14 @@ function buildLibraryTableViewSettingsScope(libraryId: string): string {
   return `library-${libraryId}`;
 }
 
+function buildDuplicateGroupsCacheKey(libraryId: string, includeSuppressed: boolean): string {
+  return `${libraryId}:${includeSuppressed ? "with-suppressed" : "visible"}`;
+}
+
+function buildDuplicateGroupKey(mode: string, signature: string): string {
+  return `${mode}:${signature}`;
+}
+
 export function LibraryDetailPage() {
   const { t } = useTranslation();
   const { libraryId = "" } = useParams();
@@ -1315,6 +1325,8 @@ export function LibraryDetailPage() {
   const [expandedGroupedSeasonKeys, setExpandedGroupedSeasonKeys] = useState<Record<string, boolean>>({});
   const [duplicateGroups, setDuplicateGroups] = useState<DuplicateGroupPage | null>(null);
   const [duplicateSearch, setDuplicateSearch] = useState("");
+  const [showSuppressedDuplicateGroups, setShowSuppressedDuplicateGroups] = useState(false);
+  const [duplicateSuppressionPendingKey, setDuplicateSuppressionPendingKey] = useState<string | null>(null);
   const initialStatisticLayoutResultRef = useRef<ReturnType<typeof getStatisticPanelLayoutReadResult> | null>(null);
   if (initialStatisticLayoutResultRef.current === null) {
     initialStatisticLayoutResultRef.current = getStatisticPanelLayoutReadResult(
@@ -1965,8 +1977,13 @@ export function LibraryDetailPage() {
     }
 
     try {
-      const payload = await api.libraryDuplicates(libraryId, { offset: 0, limit: 25, signal: controller.signal });
-      libraryDuplicateGroupsCache.set(libraryId, payload);
+      const payload = await api.libraryDuplicates(libraryId, {
+        offset: 0,
+        limit: 25,
+        includeSuppressed: showSuppressedDuplicateGroups,
+        signal: controller.signal,
+      });
+      libraryDuplicateGroupsCache.set(buildDuplicateGroupsCacheKey(libraryId, showSuppressedDuplicateGroups), payload);
       setDuplicateGroups(payload);
       setDuplicateGroupsError(null);
     } catch (reason) {
@@ -1981,6 +1998,34 @@ export function LibraryDetailPage() {
       if (showLoading) {
         setIsDuplicateGroupsLoading(false);
       }
+    }
+  });
+
+  const toggleDuplicateSuppression = useEffectEvent(async (
+    mode: "filename" | "filehash",
+    signature: string,
+    suppressed: boolean,
+  ) => {
+    const pendingKey = buildDuplicateGroupKey(mode, signature);
+    setDuplicateSuppressionPendingKey(pendingKey);
+    try {
+      if (suppressed) {
+        await api.unsuppressDuplicateGroup(libraryId, { mode, signature });
+      } else {
+        await api.suppressDuplicateGroup(libraryId, { mode, signature });
+      }
+      libraryDuplicateGroupsCache.delete(buildDuplicateGroupsCacheKey(libraryId, false));
+      libraryDuplicateGroupsCache.delete(buildDuplicateGroupsCacheKey(libraryId, true));
+      await loadDuplicateGroups(false);
+      setDuplicateGroupsError(null);
+    } catch {
+      setDuplicateGroupsError(
+        suppressed
+          ? t("libraryDetail.duplicates.restoreFailed")
+          : t("libraryDetail.duplicates.suppressFailed"),
+      );
+    } finally {
+      setDuplicateSuppressionPendingKey(null);
     }
   });
 
@@ -2445,7 +2490,8 @@ export function LibraryDetailPage() {
   useEffect(() => {
     const cachedSummary = librarySummaryCache.get(libraryId) ?? fallbackSummary ?? null;
     const cachedHistory = libraryHistoryCache.get(libraryId) ?? null;
-    const cachedDuplicateGroups = libraryDuplicateGroupsCache.get(libraryId) ?? null;
+    const duplicateGroupsCacheKey = buildDuplicateGroupsCacheKey(libraryId, showSuppressedDuplicateGroups);
+    const cachedDuplicateGroups = libraryDuplicateGroupsCache.get(duplicateGroupsCacheKey) ?? null;
 
     setComparisonByPanel({});
     setComparisonErrorByPanel({});
@@ -2469,7 +2515,7 @@ export function LibraryDetailPage() {
     void loadLibrarySummary(cachedSummary === null);
     void loadLibraryHistory(cachedHistory === null);
     void loadDuplicateGroups(cachedDuplicateGroups === null);
-  }, [libraryId]);
+  }, [libraryId, showSuppressedDuplicateGroups]);
 
   useEffect(() => {
     const statisticsCacheKey = buildLibraryStatisticsCacheKey(libraryId, visibleLibraryStatisticPanelIds);
@@ -2754,7 +2800,8 @@ export function LibraryDetailPage() {
         );
         libraryComparisonCache.delete(buildLibraryComparisonQueryKey(libraryId, selection));
       }
-      libraryDuplicateGroupsCache.delete(libraryId);
+      libraryDuplicateGroupsCache.delete(buildDuplicateGroupsCacheKey(libraryId, false));
+      libraryDuplicateGroupsCache.delete(buildDuplicateGroupsCacheKey(libraryId, true));
       libraryFileListCache.delete(fileQueryKey);
       libraryGroupedFileListCache.delete(fileQueryKey);
       setQualityScoreDetails({});
@@ -3227,6 +3274,19 @@ export function LibraryDetailPage() {
                     <div className="duplicate-panel-title-actions">
                       {duplicateGroups ? <span className="badge">{duplicateGroups.total_groups}</span> : null}
                       {!isDuplicatesPanelCollapsed ? (
+                        duplicateGroups && duplicateGroups.suppressed_group_count > 0 ? (
+                          <button
+                            type="button"
+                            className="duplicate-suppressed-toggle"
+                            onClick={() => setShowSuppressedDuplicateGroups((current) => !current)}
+                          >
+                            {showSuppressedDuplicateGroups
+                              ? t("libraryDetail.duplicates.hideSuppressed")
+                              : t("libraryDetail.duplicates.showSuppressed")}
+                          </button>
+                        ) : null
+                      ) : null}
+                      {!isDuplicatesPanelCollapsed ? (
                         <div className="data-table-search-layout duplicate-search-layout">
                           <div className="metadata-search-control duplicate-search-control">
                             <span className="metadata-search-icon-button" aria-hidden="true">
@@ -3266,14 +3326,51 @@ export function LibraryDetailPage() {
                   {duplicateGroups && filteredDuplicateGroups.length > 0 ? (
                     <div className="duplicate-group-list">
                       {filteredDuplicateGroups.map((group) => (
-                        <div key={`${group.mode}:${group.signature}`} className="media-card duplicate-group-card">
+                        <div
+                          key={`${group.mode}:${group.signature}`}
+                          className={`media-card duplicate-group-card${group.suppressed ? " is-suppressed" : ""}`}
+                        >
                           <div className="duplicate-group-summary">
-                            <div className="meta-tags">
-                              <span className="badge">{t(`libraries.duplicateDetectionModes.${group.mode}`)}</span>
-                              <span className="badge">{t("libraryDetail.duplicates.fileCount", { count: group.file_count })}</span>
-                              <span className="badge">{formatBytes(group.total_size_bytes)}</span>
+                            <div className="duplicate-group-summary-main">
+                              <div className="meta-tags">
+                                <span className="badge">{t(`libraries.duplicateDetectionModes.${group.mode}`)}</span>
+                                <span className="badge">{t("libraryDetail.duplicates.fileCount", { count: group.file_count })}</span>
+                                <span className="badge">{formatBytes(group.total_size_bytes)}</span>
+                                {group.suppressed ? (
+                                  <span className="badge">{t("libraryDetail.duplicates.suppressedBadge")}</span>
+                                ) : null}
+                              </div>
+                              <code className="scan-log-path">{group.signature}</code>
                             </div>
-                            <code className="scan-log-path">{group.signature}</code>
+                            {group.mode === "filename" || group.mode === "filehash" ? (
+                              <button
+                                type="button"
+                                className="icon-only-button duplicate-group-action"
+                                aria-label={
+                                  group.suppressed
+                                    ? t("libraryDetail.duplicates.restoreDuplicate")
+                                    : t("libraryDetail.duplicates.markNotDuplicate")
+                                }
+                                title={
+                                  group.suppressed
+                                    ? t("libraryDetail.duplicates.restoreDuplicate")
+                                    : t("libraryDetail.duplicates.markNotDuplicate")
+                                }
+                                disabled={
+                                  duplicateSuppressionPendingKey ===
+                                  buildDuplicateGroupKey(group.mode as "filename" | "filehash", group.signature)
+                                }
+                                onClick={() => {
+                                  void toggleDuplicateSuppression(
+                                    group.mode as "filename" | "filehash",
+                                    group.signature,
+                                    group.suppressed,
+                                  );
+                                }}
+                              >
+                                {group.suppressed ? <Undo2 size={17} aria-hidden="true" /> : <EyeOff size={17} aria-hidden="true" />}
+                              </button>
+                            ) : null}
                           </div>
                           <div className="scan-log-path-list duplicate-group-items-scroll">
                             {group.items.map((item) => (

--- a/frontend/src/pages/LibraryDetailPage.tsx
+++ b/frontend/src/pages/LibraryDetailPage.tsx
@@ -3264,6 +3264,16 @@ export function LibraryDetailPage() {
                 />
               );
             } else if (panel.definition.kind === "duplicates") {
+              const duplicatePanelShownGroupCount = duplicateGroups
+                ? duplicateGroups.total_groups + (showSuppressedDuplicateGroups ? duplicateGroups.suppressed_group_count : 0)
+                : 0;
+              const duplicatePanelCanExpand = Boolean(
+                duplicateGroupsError ||
+                  (isDuplicateGroupsLoading && !duplicateGroups) ||
+                  (duplicateGroups && duplicateGroups.items.length > 0),
+              );
+              const duplicatePanelCollapsed = !duplicatePanelCanExpand || isDuplicatesPanelCollapsed;
+              const hasSuppressedDuplicateGroups = Boolean(duplicateGroups && duplicateGroups.suppressed_group_count > 0);
               content = (
                 <AsyncPanel
                   title={t("libraryDetail.duplicates.title")}
@@ -3272,21 +3282,29 @@ export function LibraryDetailPage() {
                   bodyClassName="async-panel-body-scroll"
                   collapseActions={
                     <div className="duplicate-panel-title-actions">
-                      {duplicateGroups ? <span className="badge">{duplicateGroups.total_groups}</span> : null}
-                      {!isDuplicatesPanelCollapsed ? (
-                        duplicateGroups && duplicateGroups.suppressed_group_count > 0 ? (
-                          <button
-                            type="button"
-                            className="duplicate-suppressed-toggle"
-                            onClick={() => setShowSuppressedDuplicateGroups((current) => !current)}
-                          >
-                            {showSuppressedDuplicateGroups
-                              ? t("libraryDetail.duplicates.hideSuppressed")
-                              : t("libraryDetail.duplicates.showSuppressed")}
-                          </button>
-                        ) : null
+                      {duplicateGroups && duplicatePanelShownGroupCount > 0 ? (
+                        <span className="badge">{duplicatePanelShownGroupCount}</span>
                       ) : null}
-                      {!isDuplicatesPanelCollapsed ? (
+                      {hasSuppressedDuplicateGroups ? (
+                        <button
+                          type="button"
+                          className="duplicate-suppressed-toggle"
+                          onClick={() => {
+                            setShowSuppressedDuplicateGroups((current) => {
+                              const next = !current;
+                              if (next) {
+                                setIsDuplicatesPanelCollapsed(false);
+                              }
+                              return next;
+                            });
+                          }}
+                        >
+                          {showSuppressedDuplicateGroups
+                            ? t("libraryDetail.duplicates.hideSuppressed")
+                            : t("libraryDetail.duplicates.showSuppressed")}
+                        </button>
+                      ) : null}
+                      {duplicatePanelCanExpand && !duplicatePanelCollapsed ? (
                         <div className="data-table-search-layout duplicate-search-layout">
                           <div className="metadata-search-control duplicate-search-control">
                             <span className="metadata-search-icon-button" aria-hidden="true">
@@ -3318,8 +3336,13 @@ export function LibraryDetailPage() {
                   }
                   collapseButtonClassName="async-panel-toggle-icon-button-flat"
                   collapseState={{
-                    collapsed: isDuplicatesPanelCollapsed,
-                    onToggle: () => setIsDuplicatesPanelCollapsed((current) => !current),
+                    collapsed: duplicatePanelCollapsed,
+                    disabled: !duplicatePanelCanExpand,
+                    onToggle: () => {
+                      if (duplicatePanelCanExpand) {
+                        setIsDuplicatesPanelCollapsed((current) => !current);
+                      }
+                    },
                     bodyId: "library-duplicates-panel-body",
                   }}
                 >

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "medialyze"
-version = "0.10.2"
+version = "0.10.3"
 description = "Self-hosted media library analyzer for technical video metadata."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "medialyze"
-version = "0.10.3"
+version = "0.10.4"
 description = "Self-hosted media library analyzer for technical video metadata."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/dev-local.ps1
+++ b/scripts/dev-local.ps1
@@ -1,0 +1,141 @@
+$ErrorActionPreference = "Stop"
+
+$RootDir = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$VenvDir = if ($env:VENV_DIR) { $env:VENV_DIR } else { Join-Path $RootDir ".venv" }
+$ConfigPath = if ($env:CONFIG_PATH) { $env:CONFIG_PATH } else { Join-Path $RootDir ".local-config" }
+$MediaRoot = if ($env:MEDIA_ROOT) { $env:MEDIA_ROOT } else { Join-Path $HOME "Desktop" }
+$BackendHost = if ($env:BACKEND_HOST) { $env:BACKEND_HOST } else { "127.0.0.1" }
+$BackendPort = if ($env:BACKEND_PORT) { [int]$env:BACKEND_PORT } else { 8080 }
+$FrontendPort = if ($env:FRONTEND_PORT) { [int]$env:FRONTEND_PORT } else { 5173 }
+$BackendLog = if ($env:BACKEND_LOG) { $env:BACKEND_LOG } else { Join-Path $ConfigPath "dev-api.log" }
+$BackendPidFile = if ($env:BACKEND_PID_FILE) { $env:BACKEND_PID_FILE } else { Join-Path $ConfigPath "dev-api.pid" }
+$PythonExe = Join-Path $VenvDir "Scripts\python.exe"
+$ShellExe = (Get-Process -Id $PID).Path
+
+New-Item -ItemType Directory -Force -Path $ConfigPath | Out-Null
+
+if (-not (Test-Path $PythonExe -PathType Leaf)) {
+    Write-Host "Python virtualenv not found at $VenvDir"
+    Write-Host "Create it first, then rerun this script."
+    exit 1
+}
+
+if (-not (Test-Path (Join-Path $RootDir "frontend\node_modules") -PathType Container)) {
+    Write-Host "frontend/node_modules is missing."
+    Write-Host "Run: npm --prefix frontend install"
+    exit 1
+}
+
+if (-not (Test-Path $MediaRoot -PathType Container)) {
+    Write-Host "MEDIA_ROOT does not exist: $MediaRoot"
+    exit 1
+}
+
+$env:CONFIG_PATH = $ConfigPath
+$env:MEDIA_ROOT = $MediaRoot
+
+function Stop-Backend {
+    if (Test-Path $BackendPidFile -PathType Leaf) {
+        $existingPid = Get-Content $BackendPidFile -ErrorAction SilentlyContinue | Select-Object -First 1
+        if ($existingPid) {
+            $existingPid = $existingPid.Trim()
+        }
+        if ($existingPid) {
+            try {
+                $process = Get-Process -Id ([int]$existingPid) -ErrorAction Stop
+                Stop-Process -Id $process.Id -ErrorAction SilentlyContinue
+                Start-Sleep -Milliseconds 500
+            }
+            catch {
+            }
+        }
+        Remove-Item $BackendPidFile -Force -ErrorAction SilentlyContinue
+    }
+
+    try {
+        $listenerPids = Get-NetTCPConnection -LocalPort $BackendPort -State Listen -ErrorAction Stop |
+            Select-Object -ExpandProperty OwningProcess -Unique
+    }
+    catch {
+        $listenerPids = @()
+    }
+
+    foreach ($listenerPid in $listenerPids) {
+        if ($listenerPid) {
+            Stop-Process -Id $listenerPid -ErrorAction SilentlyContinue
+        }
+    }
+
+    if ($listenerPids.Count -gt 0) {
+        Start-Sleep -Milliseconds 500
+    }
+}
+
+try {
+    Stop-Backend
+
+    Write-Host "Starting backend on http://$BackendHost`:$BackendPort"
+    Write-Host "Backend log: $BackendLog"
+
+    $quotedRootDir = $RootDir.Replace("'", "''")
+    $quotedPythonExe = $PythonExe.Replace("'", "''")
+    $quotedBackendLog = $BackendLog.Replace("'", "''")
+    $backendCommand = @"
+Set-Location -LiteralPath '$quotedRootDir'
+& '$quotedPythonExe' -m uvicorn backend.app.main:app --reload --host '$BackendHost' --port '$BackendPort' *> '$quotedBackendLog'
+"@
+
+    $backendProcess = Start-Process `
+        -FilePath $ShellExe `
+        -ArgumentList @(
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-Command",
+            $backendCommand
+        ) `
+        -WorkingDirectory $RootDir `
+        -WindowStyle Hidden `
+        -PassThru
+
+    Set-Content -Path $BackendPidFile -Value $backendProcess.Id
+
+    $backendReady = $false
+    for ($attempt = 0; $attempt -lt 80; $attempt++) {
+        if ($backendProcess.HasExited) {
+            Write-Host "Backend exited during startup. Recent log output:"
+            Get-Content $BackendLog -Tail 80 -ErrorAction SilentlyContinue
+            exit 1
+        }
+
+        try {
+            Invoke-WebRequest -Uri "http://$BackendHost`:$BackendPort/api/health" -UseBasicParsing | Out-Null
+            $backendReady = $true
+            break
+        }
+        catch {
+            Start-Sleep -Milliseconds 250
+        }
+    }
+
+    if (-not $backendReady) {
+        Write-Host "Backend did not become healthy in time. Recent log output:"
+        Get-Content $BackendLog -Tail 80 -ErrorAction SilentlyContinue
+        exit 1
+    }
+
+    Write-Host "Backend is ready."
+    Write-Host "Starting frontend on http://127.0.0.1:$FrontendPort"
+
+    Push-Location (Join-Path $RootDir "frontend")
+    try {
+        & npm.cmd run dev -- --port $FrontendPort
+        exit $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+}
+finally {
+    Stop-Backend
+}

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -487,11 +487,13 @@ def test_dashboard_history_route_returns_visible_library_aggregation() -> None:
     assert response.status_code == 200
     payload = response.json()
     assert payload["visible_library_ids"] == [visible_library_id]
+    assert payload["visible_libraries"] == [{"id": visible_library_id, "name": "Visible history"}]
     assert payload["oldest_snapshot_day"] == "2026-04-10"
     assert payload["newest_snapshot_day"] == "2026-04-10"
     assert payload["points"][0]["trend_metrics"]["total_files"] == 2
     assert payload["points"][0]["trend_metrics"]["resolution_counts"] == {"4k": 2}
     assert payload["points"][0]["trend_metrics"]["category_counts"]["resolution"] == {"4k": 2}
+    assert payload["points"][0]["trend_metrics"]["category_counts"]["library"] == {str(visible_library_id): 2}
     assert payload["points"][0]["trend_metrics"]["numeric_summaries"]["bitrate"]["average"] == 8_000_000
 
 

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1200,6 +1200,8 @@ def test_library_duplicates_route_returns_empty_page_when_detection_is_off() -> 
         "mode": "off",
         "total_groups": 0,
         "duplicate_file_count": 0,
+        "include_suppressed": False,
+        "suppressed_group_count": 0,
         "offset": 0,
         "limit": 25,
         "items": [],
@@ -1284,3 +1286,109 @@ def test_library_duplicates_route_returns_both_group_types_for_combined_mode() -
     assert [item["mode"] for item in payload["items"]] == ["filehash", "filename"]
     assert payload["items"][0]["signature"] == "deadbeef"
     assert payload["items"][1]["signature"] == "movie name 2024"
+
+
+def test_library_duplicate_suppression_routes_hide_and_restore_groups() -> None:
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    with session_factory() as db:
+        library = Library(
+            name="Suppressed Movies",
+            path="/tmp/suppressed-movies",
+            type=LibraryType.movies,
+            scan_mode=ScanMode.manual,
+            duplicate_detection_mode=DuplicateDetectionMode.filename,
+            scan_config={},
+        )
+        db.add(library)
+        db.flush()
+        db.add_all(
+            [
+                MediaFile(
+                    library_id=library.id,
+                    relative_path="Movie.Name.2024.mkv",
+                    filename="Movie.Name.2024.mkv",
+                    extension="mkv",
+                    size_bytes=10,
+                    mtime=1.0,
+                    filename_signature="movie name 2024",
+                ),
+                MediaFile(
+                    library_id=library.id,
+                    relative_path="movie_name_2024.mp4",
+                    filename="movie_name_2024.mp4",
+                    extension="mp4",
+                    size_bytes=12,
+                    mtime=1.0,
+                    filename_signature="movie name 2024",
+                ),
+            ]
+        )
+        db.commit()
+
+        client = _build_test_app(db)
+        create_response = client.post(
+            f"/api/libraries/{library.id}/duplicates/suppressions",
+            json={"mode": "filename", "signature": "movie name 2024"},
+        )
+        visible_response = client.get(f"/api/libraries/{library.id}/duplicates")
+        hidden_response = client.get(f"/api/libraries/{library.id}/duplicates?include_suppressed=true")
+        delete_response = client.delete(
+            f"/api/libraries/{library.id}/duplicates/suppressions",
+            params={"mode": "filename", "signature": "movie name 2024"},
+        )
+        restored_response = client.get(f"/api/libraries/{library.id}/duplicates")
+
+    assert create_response.status_code == 201
+    assert create_response.json()["signature"] == "movie name 2024"
+    assert visible_response.status_code == 200
+    assert visible_response.json()["total_groups"] == 0
+    assert visible_response.json()["duplicate_file_count"] == 0
+    assert visible_response.json()["suppressed_group_count"] == 1
+    assert visible_response.json()["items"] == []
+    assert hidden_response.status_code == 200
+    assert hidden_response.json()["include_suppressed"] is True
+    assert hidden_response.json()["items"][0]["suppressed"] is True
+    assert hidden_response.json()["items"][0]["signature"] == "movie name 2024"
+    assert delete_response.status_code == 204
+    assert restored_response.json()["total_groups"] == 1
+    assert restored_response.json()["duplicate_file_count"] == 2
+    assert restored_response.json()["suppressed_group_count"] == 0
+
+
+def test_library_duplicate_suppression_routes_validate_inputs() -> None:
+    engine = create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    with session_factory() as db:
+        library = Library(
+            name="Validation Movies",
+            path="/tmp/validation-movies",
+            type=LibraryType.movies,
+            scan_mode=ScanMode.manual,
+            duplicate_detection_mode=DuplicateDetectionMode.filename,
+            scan_config={},
+        )
+        db.add(library)
+        db.commit()
+
+        client = _build_test_app(db)
+        unknown_response = client.post(
+            "/api/libraries/999/duplicates/suppressions",
+            json={"mode": "filename", "signature": "movie name 2024"},
+        )
+        empty_response = client.post(
+            f"/api/libraries/{library.id}/duplicates/suppressions",
+            json={"mode": "filename", "signature": "   "},
+        )
+        invalid_mode_response = client.post(
+            f"/api/libraries/{library.id}/duplicates/suppressions",
+            json={"mode": "both", "signature": "movie name 2024"},
+        )
+
+    assert unknown_response.status_code == 404
+    assert empty_response.status_code == 400
+    assert invalid_mode_response.status_code == 400

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -12,6 +12,8 @@ from backend.app.services.duplicates import (
     FilenameDuplicateDetectionStrategy,
     get_duplicate_detection_strategy,
     list_library_duplicate_groups,
+    suppress_duplicate_group,
+    unsuppress_duplicate_group,
 )
 
 
@@ -246,3 +248,123 @@ def test_combined_duplicate_detection_groups_include_filename_and_filehash_match
     assert groups.items[1].signature == "movie name 2024"
     assert {item.filename for item in groups.items[0].items} == {"hash-a.mkv", "totally-different-name.mp4"}
     assert {item.filename for item in groups.items[1].items} == {"Movie.Name.2024.mkv", "movie_name_2024.mp4"}
+
+
+def test_duplicate_suppression_hides_and_restores_filename_groups(tmp_path: Path) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    library_dir = tmp_path / "library"
+    library_dir.mkdir()
+    files = [library_dir / "Movie.Name.2024.mkv", library_dir / "movie_name_2024.mp4"]
+    for file_path in files:
+        file_path.write_text(file_path.name)
+
+    strategy = get_duplicate_detection_strategy(DuplicateDetectionMode.filename)
+
+    with session_factory() as db:
+        library = Library(
+            name="Movies",
+            path=str(library_dir),
+            type=LibraryType.movies,
+            scan_mode=ScanMode.manual,
+            duplicate_detection_mode=DuplicateDetectionMode.filename,
+            scan_config={},
+        )
+        db.add(library)
+        db.flush()
+
+        for file_path in files:
+            media_file = MediaFile(
+                library_id=library.id,
+                relative_path=file_path.name,
+                filename=file_path.name,
+                extension=file_path.suffix.lstrip("."),
+                size_bytes=file_path.stat().st_size,
+                mtime=file_path.stat().st_mtime,
+            )
+            strategy.apply_payload(media_file, strategy.build_payload(file_path))
+            db.add(media_file)
+
+        db.commit()
+        suppression = suppress_duplicate_group(db, library.id, DuplicateDetectionMode.filename, "movie name 2024")
+        groups = list_library_duplicate_groups(db, library.id)
+        groups_with_suppressed = list_library_duplicate_groups(db, library.id, include_suppressed=True)
+        restored = unsuppress_duplicate_group(db, library.id, DuplicateDetectionMode.filename, "movie name 2024")
+        restored_groups = list_library_duplicate_groups(db, library.id)
+
+    assert suppression is not None
+    assert groups.total_groups == 0
+    assert groups.duplicate_file_count == 0
+    assert groups.suppressed_group_count == 1
+    assert groups.items == []
+    assert groups_with_suppressed.total_groups == 0
+    assert groups_with_suppressed.duplicate_file_count == 0
+    assert groups_with_suppressed.suppressed_group_count == 1
+    assert groups_with_suppressed.items[0].suppressed is True
+    assert groups_with_suppressed.items[0].signature == "movie name 2024"
+    assert restored is True
+    assert restored_groups.total_groups == 1
+    assert restored_groups.duplicate_file_count == 2
+    assert restored_groups.suppressed_group_count == 0
+
+
+def test_duplicate_suppression_is_mode_specific_for_combined_detection(tmp_path: Path) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+    library_dir = tmp_path / "library"
+    library_dir.mkdir()
+    filename_a = library_dir / "Movie.Name.2024.mkv"
+    filename_b = library_dir / "movie_name_2024.mp4"
+    hash_a = library_dir / "hash-a.mkv"
+    hash_b = library_dir / "totally-different-name.mp4"
+    filename_a.write_text("cut-a")
+    filename_b.write_text("cut-b")
+    hash_a.write_text("same-content")
+    hash_b.write_text("same-content")
+
+    strategy = get_duplicate_detection_strategy(DuplicateDetectionMode.both)
+
+    with session_factory() as db:
+        library = Library(
+            name="Movies",
+            path=str(library_dir),
+            type=LibraryType.movies,
+            scan_mode=ScanMode.manual,
+            duplicate_detection_mode=DuplicateDetectionMode.both,
+            scan_config={},
+        )
+        db.add(library)
+        db.flush()
+
+        for file_path in (filename_a, filename_b, hash_a, hash_b):
+            media_file = MediaFile(
+                library_id=library.id,
+                relative_path=file_path.name,
+                filename=file_path.name,
+                extension=file_path.suffix.lstrip("."),
+                size_bytes=file_path.stat().st_size,
+                mtime=file_path.stat().st_mtime,
+            )
+            strategy.apply_payload(media_file, strategy.build_payload(file_path))
+            db.add(media_file)
+
+        db.commit()
+        original = list_library_duplicate_groups(db, library.id)
+        filehash_signature = next(group.signature for group in original.items if group.mode == DuplicateDetectionMode.filehash)
+        suppress_duplicate_group(db, library.id, DuplicateDetectionMode.filehash, filehash_signature)
+        visible = list_library_duplicate_groups(db, library.id)
+        with_suppressed = list_library_duplicate_groups(db, library.id, include_suppressed=True)
+        suppress_duplicate_group(db, library.id, DuplicateDetectionMode.filehash, filehash_signature)
+        idempotent = list_library_duplicate_groups(db, library.id)
+
+    assert visible.total_groups == 1
+    assert visible.duplicate_file_count == 2
+    assert visible.items[0].mode == DuplicateDetectionMode.filename
+    assert visible.items[0].signature == "movie name 2024"
+    assert with_suppressed.suppressed_group_count == 1
+    assert [group.suppressed for group in with_suppressed.items] == [True, False]
+    assert idempotent.suppressed_group_count == 1

--- a/tests/test_history_services.py
+++ b/tests/test_history_services.py
@@ -259,16 +259,21 @@ def test_get_dashboard_history_aggregates_visible_libraries() -> None:
         payload = get_dashboard_history(db)
 
     assert payload.visible_library_ids == [visible_library.id]
+    assert [item.model_dump() for item in payload.visible_libraries] == [
+        {"id": visible_library.id, "name": "Visible"},
+    ]
     assert payload.oldest_snapshot_day == "2026-03-24"
     assert payload.newest_snapshot_day == "2026-03-25"
     assert [point.snapshot_day for point in payload.points] == ["2026-03-24", "2026-03-25"]
     assert payload.points[0].trend_metrics.total_files == 2
     assert payload.points[0].trend_metrics.resolution_counts == {"4k": 2}
+    assert payload.points[0].trend_metrics.category_counts["library"] == {str(visible_library.id): 2}
     assert payload.points[0].trend_metrics.average_bitrate == 8_000_000.0
     assert payload.points[0].trend_metrics.totals["total_size_bytes"] == 3_000
     assert payload.points[0].trend_metrics.totals["total_duration_seconds"] == 10_800.0
     assert payload.points[0].trend_metrics.numeric_summaries["size"].average == 1_500.0
     assert payload.points[0].trend_metrics.numeric_summaries["resolution_mp"].average == 8.2944
+    assert payload.points[1].trend_metrics.category_counts["library"] == {str(visible_library.id): 3}
 
 
 def test_build_library_history_snapshot_includes_trend_metrics() -> None:


### PR DESCRIPTION
## Summary

Replaced the Linux desktop AppImage ffprobe bundle with a static build to eliminate shared-library dependencies. Implemented functionality for suppressing and restoring duplicate groups, along with enhancements to the duplicate panel's state management and styling. Added a library mix metric to the dashboard history and improved the Windows development setup with a new script and a retry mechanism for the Electron packaging process.

## Changes

- Enhanced duplicate group management features
- Introduced a library mix metric in the dashboard
- Streamlined local development setup for Windows

## Testing

- Verified functionality for duplicate group suppression and restoration
- Tested the new local development script on Windows

## Checklist

- [x] I tested the change locally.
- [x] I updated docs if behavior/config changed.
- [x] I kept the scope focused (single concern).
- [x] I did not include secrets or local machine artifacts.

