### PR TITLE
Add Unraid Docker template and spanish translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## vUnreleased
 
+### ✨ New
+
+- add an Unraid Community Applications Docker template and repository profile for MediaLyze deployments, based on original template contribution in [#117](https://github.com/frederikemmer/MediaLyze/issues/117) by [@jvdivx](https://github.com/jvdivx) 
+- solid starting point for Spanish translation [#146](https://github.com/frederikemmer/MediaLyze/pull/146) by [@jvdivx](https://github.com/jvdivx)
+
+### New Contributors
+
+[@jvdivx](https://github.com/jvdivx) in [#117](https://github.com/frederikemmer/MediaLyze/issues/117) & [#146](https://github.com/frederikemmer/MediaLyze/pull/146)
+
 ## v0.12.2
 
 >2026-05-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## vUnreleased
 
-## v0.12.3
+## v0.13.0
 
 >2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## vUnreleased
 
+## v0.12.3
+
+>2026-05-31
+
 ### ✨ New
 
 - add an Unraid Community Applications Docker template and repository profile for MediaLyze deployments, based on original template contribution in [#117](https://github.com/frederikemmer/MediaLyze/issues/117) by [@jvdivx](https://github.com/jvdivx) 
 - solid starting point for Spanish translation [#146](https://github.com/frederikemmer/MediaLyze/pull/146) by [@jvdivx](https://github.com/jvdivx)
+- relicense change from MIT to GNU Affero General Public License v3.0 (`AGPL-3.0`)
 
 ### New Contributors
 
@@ -20,7 +25,7 @@ All notable changes to this project will be documented in this file.
 ### ✨ New
 
 - redesign duplications panel
-- new four-state header toggle for all, hash-only, filename-only, and hidden duplicate views ([#144](https://github.com/frederikemmer/MediaLyze/issues/144))
+- new four-state header toggle for all, hash-only, filename-only, and hidden duplicate views [#144](https://github.com/frederikemmer/MediaLyze/issues/144)
 
 ### 🐛 Bug fixes
 
@@ -48,8 +53,8 @@ All notable changes to this project will be documented in this file.
 ### 🐛 Bug fixes
 
 - avoid noisy file-history events when rescans only populate newly supported metadata fields for otherwise unchanged files
-- schedule daily scans in the configured local timezone instead of UTC so Docker `TZ` settings are respected ([#139](https://github.com/frederikemmer/MediaLyze/issues/139))
-- keep Linux AppImage media analysis on the packaged static `ffprobe` binary so scans do not depend on incompatible host FFmpeg shared libraries ([#127](https://github.com/frederikemmer/MediaLyze/issues/127))
+- schedule daily scans in the configured local timezone instead of UTC so Docker `TZ` settings are respected [#139](https://github.com/frederikemmer/MediaLyze/issues/139)
+- keep Linux AppImage media analysis on the packaged static `ffprobe` binary so scans do not depend on incompatible host FFmpeg shared libraries [#127](https://github.com/frederikemmer/MediaLyze/issues/127)
 
 ## v0.11.2
 
@@ -77,8 +82,8 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 
-- allow creating multiple libraries that share the same root path when they use different selected subdirectories (`scan_config.selected_paths`), and migrate existing SQLite databases to drop the legacy unique constraint on `libraries.path` ([#132](https://github.com/frederikemmer/MediaLyze/issues/132))
-- separate video codec, video dynamic-range bit-depth, and HDR-profile statistics so codec panels no longer mix HEVC bit depth into codec labels ([#129](https://github.com/frederikemmer/MediaLyze/issues/129))
+- allow creating multiple libraries that share the same root path when they use different selected subdirectories (`scan_config.selected_paths`), and migrate existing SQLite databases to drop the legacy unique constraint on `libraries.path` [#132](https://github.com/frederikemmer/MediaLyze/issues/132)
+- separate video codec, video dynamic-range bit-depth, and HDR-profile statistics so codec panels no longer mix HEVC bit depth into codec labels [#129](https://github.com/frederikemmer/MediaLyze/issues/129)
 
 ## v0.11.0
 
@@ -120,7 +125,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 
-- replace the Linux desktop AppImage `ffprobe` bundle with a pinned static `ffprobe` build so media scans no longer depend on host or bundled FFmpeg shared-library resolution; `FFPROBE_PATH` remains available for explicit system `ffprobe` overrides ([#127](https://github.com/frederikemmer/MediaLyze/issues/127))
+- replace the Linux desktop AppImage `ffprobe` bundle with a pinned static `ffprobe` build so media scans no longer depend on host or bundled FFmpeg shared-library resolution; `FFPROBE_PATH` remains available for explicit system `ffprobe` overrides [#127](https://github.com/frederikemmer/MediaLyze/issues/127)
 
 ## v0.10.2
 
@@ -128,8 +133,8 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 
-- route packaged Linux desktop analysis through a bundled `ffprobe` launcher that sets its own library path before executing `ffprobe`, preventing AppImage scans from falling back to incompatible host FFmpeg libraries; `FFPROBE_PATH` still supports explicit system `ffprobe` overrides ([#127](https://github.com/frederikemmer/MediaLyze/issues/127))
-- make `MediaLyze.AppImage --version` print the packaged desktop app version so users can verify the exact AppImage build they are running ([#127](https://github.com/frederikemmer/MediaLyze/issues/127))
+- route packaged Linux desktop analysis through a bundled `ffprobe` launcher that sets its own library path before executing `ffprobe`, preventing AppImage scans from falling back to incompatible host FFmpeg libraries; `FFPROBE_PATH` still supports explicit system `ffprobe` overrides [#127](https://github.com/frederikemmer/MediaLyze/issues/127)
+- make `MediaLyze.AppImage --version` print the packaged desktop app version so users can verify the exact AppImage build they are running [#127](https://github.com/frederikemmer/MediaLyze/issues/127)
 
 ## v0.10.1
 
@@ -137,7 +142,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 
-- bundle Linux desktop `ffprobe` shared-library dependencies into AppImage builds and load them at runtime so scans no longer fail when the host distribution has incompatible FFmpeg library versions ([#127](https://github.com/frederikemmer/MediaLyze/issues/127))
+- bundle Linux desktop `ffprobe` shared-library dependencies into AppImage builds and load them at runtime so scans no longer fail when the host distribution has incompatible FFmpeg library versions [#127](https://github.com/frederikemmer/MediaLyze/issues/127)
 
 ## v0.10.0
 
@@ -145,7 +150,7 @@ All notable changes to this project will be documented in this file.
 
 ### ✨ New
 
-- add **Music** library type and basic audio-file support for `.mp3`, `.flac`, `.m4a`, `.aac`, `.opus`, `.wav`, and `.wma` files ([#76](https://github.com/frederikemmer/MediaLyze/issues/76))
+- add **Music** library type and basic audio-file support for `.mp3`, `.flac`, `.m4a`, `.aac`, `.opus`, `.wav`, and `.wma` files [#76](https://github.com/frederikemmer/MediaLyze/issues/76)
 - extract and persist music-specific metadata tags (title, artist, album, album artist, genre, date, disc, composer) from audio files when scanning
 - make file discovery library-type-aware so **Movies** and **Shows** libraries scan only video files, **Music** libraries scan only audio files, and **Mixed**/**Other** libraries scan both
 - filter analyzed-files table columns by library type to hide video-exclusive fields (video codec, resolution, HDR type, bitrate) when viewing Music libraries
@@ -167,7 +172,7 @@ All notable changes to this project will be documented in this file.
 ### ✨ New
 
 - add stable desktop release asset names so README download links can point at `releases/latest/download/...` and always fetch the newest published desktop build
-- add a **Scheduled** scan mode that runs a daily incremental scan at a configurable time of day (HH:MM); the existing interval-based mode is renamed to **Time Interval** in the UI; a tooltip in the time picker explains that only one scan per 24 hours is currently supported and that the `TZ` environment variable should be set correctly ([#124](https://github.com/frederikemmer/MediaLyze/issues/124))
+- add a **Scheduled** scan mode that runs a daily incremental scan at a configurable time of day (HH:MM); the existing interval-based mode is renamed to **Time Interval** in the UI; a tooltip in the time picker explains that only one scan per 24 hours is currently supported and that the `TZ` environment variable should be set correctly [#124](https://github.com/frederikemmer/MediaLyze/issues/124)
 - allow creating one library from multiple selected directories; MediaLyze stores a shared root internally, scans only the selected directories, and keeps the selected directory names in analyzed file relative paths instead of stripping them away
 
 ## v0.9.0
@@ -176,7 +181,7 @@ All notable changes to this project will be documented in this file.
 
 ### ✨ New
 
-- add a **folder & pattern recognition** settings panel with configurable **show/season**, **bonus-content**, and ignore-pattern rules; bonus content can now be excluded from scans or retained as classified bonus media, and Shows/Mixed libraries gain series, season, and episode recognition with tree/detail views ([#74](https://github.com/frederikemmer/MediaLyze/issues/74)) ([#47](https://github.com/frederikemmer/MediaLyze/issues/47))
+- add a **folder & pattern recognition** settings panel with configurable **show/season**, **bonus-content**, and ignore-pattern rules; bonus content can now be excluded from scans or retained as classified bonus media, and Shows/Mixed libraries gain series, season, and episode recognition with tree/detail views [#74](https://github.com/frederikemmer/MediaLyze/issues/74) [#47](https://github.com/frederikemmer/MediaLyze/issues/47)
 - view **changelog** when clicking on version number
 - make the pattern-rule sections individually collapsible, link to the pattern documentation from settings, and classify all videos inside recognized season folders as episodes without requiring configurable episode filename regexes
 - add a `Folder depth` show/season recognition mode with configurable series and season depths, make it the default, and only show regex inputs when the regex mode is selected
@@ -202,7 +207,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 
-- preserve customized dashboard and library panel layouts across updates by avoiding automatic default-panel injection and avoiding write-back during layout reads ([#118](https://github.com/frederikemmer/MediaLyze/issues/118))
+- preserve customized dashboard and library panel layouts across updates by avoiding automatic default-panel injection and avoiding write-back during layout reads [#118](https://github.com/frederikemmer/MediaLyze/issues/118)
 - make the analyzed-files empty state compact and centered instead of showing a large notice box
 - keep the compact empty analyzed-files state stable while search filters are edited, avoiding spinner flicker and layout jumps
 - improve overall app performance
@@ -266,7 +271,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 
-- broaden ffprobe-based spatial-audio detection so additional explicit Atmos metadata variants beyond `stream.profile` are recognized during analysis; existing libraries may need a full rescan to refresh previously analyzed files ([#107](https://github.com/frederikemmer/MediaLyze/issues/107))
+- broaden ffprobe-based spatial-audio detection so additional explicit Atmos metadata variants beyond `stream.profile` are recognized during analysis; existing libraries may need a full rescan to refresh previously analyzed files [#107](https://github.com/frederikemmer/MediaLyze/issues/107)
 
 ## v0.7.0
 
@@ -274,8 +279,8 @@ All notable changes to this project will be documented in this file.
 
 ### ✨ New
 
-- add configurable metric-comparison statistic panels on the dashboard and library detail pages, with two-axis selection, heatmap / scatter / bar renderers, and dedicated comparison API endpoints for direct context such as `size` versus `duration` ([#102](https://github.com/frederikemmer/MediaLyze/issues/102))
-- extend metric-comparison charts with a numeric `Resolution - MP` axis option, show the active renderer icon directly in the toolbar button, and add an App Settings control for the scatter-plot sample limit ([#102](https://github.com/frederikemmer/MediaLyze/issues/102))
+- add configurable metric-comparison statistic panels on the dashboard and library detail pages, with two-axis selection, heatmap / scatter / bar renderers, and dedicated comparison API endpoints for direct context such as `size` versus `duration` [#102](https://github.com/frederikemmer/MediaLyze/issues/102)
+- extend metric-comparison charts with a numeric `Resolution - MP` axis option, show the active renderer icon directly in the toolbar button, and add an App Settings control for the scatter-plot sample limit [#102](https://github.com/frederikemmer/MediaLyze/issues/102)
 - add inline statistic-panel layout editing on the dashboard and per-library detail pages, including a visible `Dashboard` page title, animated edit controls, add-panel menus, drag-and-drop reordering, per-panel resize controls, and browser-persisted layouts for each page context
 - add curated first-run default layouts for dashboard and library statistic panels, allow intentionally empty saved panel layouts, and add a `History` restore-default action to the inline layout toolbar
 - add a new `unlimited panel size` feature flag that removes the current 4-row height cap for dashboard and library statistic panels while still keeping panel width constrained by the underlying 4-column grid
@@ -286,7 +291,7 @@ All notable changes to this project will be documented in this file.
 - remount statistic charts when resized smaller so comparison and histogram panels redraw correctly after inline panel-size changes, restore top-aligned list panels, and make newly added statistic panels default to `1x2`
 - align dashboard and library statistic layout controls with the existing header-style button design language so Darkmode no longer renders bright low-contrast white action circles
 - bundle macOS desktop `ffprobe` dependencies into the packaged app and rewrite non-system `dylib` loader paths so scans no longer fail on machines without the original Homebrew cellar layout
-- make dashboard statistic panels behave as non-interactive read-only summaries again instead of hinting at missing cross-library drill-downs; only scatter points in dashboard comparison panels still open file details ([#104](https://github.com/frederikemmer/MediaLyze/issues/104))
+- make dashboard statistic panels behave as non-interactive read-only summaries again instead of hinting at missing cross-library drill-downs; only scatter points in dashboard comparison panels still open file details [#104](https://github.com/frederikemmer/MediaLyze/issues/104)
 
 ## v0.6.0
 
@@ -299,7 +304,7 @@ All notable changes to this project will be documented in this file.
 ### 🐛 Bug fixes
 
 - extend structured numeric analyzed-files filters to support comma-separated `AND` ranges such as `>=4GB,<8GB`, including the new bitrate-based search fields used by the histogram panels
-- include `desktop/ffprobe-paths.cjs` in packaged Electron app builds and add desktop packaging regression tests so macOS startup no longer fails with `Cannot find module './ffprobe-paths.cjs'` ([#99](https://github.com/frederikemmer/MediaLyze/issues/99))
+- include `desktop/ffprobe-paths.cjs` in packaged Electron app builds and add desktop packaging regression tests so macOS startup no longer fails with `Cannot find module './ffprobe-paths.cjs'` [#99](https://github.com/frederikemmer/MediaLyze/issues/99)
 
 ## v0.5.0
 
@@ -307,9 +312,9 @@ All notable changes to this project will be documented in this file.
 
 ### ✨ New
 
-- add lightweight analyzed-files codec tooltips that lazy-load per-file video, audio, and subtitle stream details, including language, codec, channel layout, and subtitle source metadata, and make table tooltip visibility configurable per statistic column in App Settings ([#93](https://github.com/frederikemmer/MediaLyze/issues/93))
-- add first-class spatial-audio support for `Dolby Atmos` and `DTS:X`, including ffprobe profile detection, analyzed-files filtering and sorting, library statistics, CSV export, and audio tooltip/detail rendering ([#94](https://github.com/frederikemmer/MediaLyze/issues/94))
-- add container statistics and analyzed-files container filtering, sorting, CSV export, and configurable table/panel visibility for library views ([#97](https://github.com/frederikemmer/MediaLyze/issues/97))
+- add lightweight analyzed-files codec tooltips that lazy-load per-file video, audio, and subtitle stream details, including language, codec, channel layout, and subtitle source metadata, and make table tooltip visibility configurable per statistic column in App Settings [#93](https://github.com/frederikemmer/MediaLyze/issues/93)
+- add first-class spatial-audio support for `Dolby Atmos` and `DTS:X`, including ffprobe profile detection, analyzed-files filtering and sorting, library statistics, CSV export, and audio tooltip/detail rendering [#94](https://github.com/frederikemmer/MediaLyze/issues/94)
+- add container statistics and analyzed-files container filtering, sorting, CSV export, and configurable table/panel visibility for library views [#97](https://github.com/frederikemmer/MediaLyze/issues/97)
 - rework the file-detail page so the `Format` panel renders structured metadata rows instead of raw format JSON, and make all detail panels globally collapsible and reorderable with browser-persisted state
 - allow `Container`, `Spatial audio`, `Subtitle codecs`, and `Subtitle sources` to be enabled as optional dashboard statistic panels through the existing statistics settings
 - update the default statistics preset for fresh installs to match the expanded dashboard/table layout while preserving already stored statistic settings on upgrades and only appending newly introduced options
@@ -318,7 +323,7 @@ All notable changes to this project will be documented in this file.
 
 - keep analyzed-files tooltips exclusive so opening or scrolling to another table area closes stale codec and score tooltips instead of leaving multiple overlays on screen
 - fix the desktop release build after `v0.4.1` by completing strict frontend test app-settings mocks for the new feature flags and replacing the Windows `ffprobe` bundle step's brittle Chocolatey install with a direct archive download plus retries
-- reanalyze unchanged media files when external subtitle sidecars are added or removed so subtitle statistics and quality scoring stay in sync with internal subtitles ([#95](https://github.com/frederikemmer/MediaLyze/issues/95))
+- reanalyze unchanged media files when external subtitle sidecars are added or removed so subtitle statistics and quality scoring stay in sync with internal subtitles [#95](https://github.com/frederikemmer/MediaLyze/issues/95)
 
 ## v0.4.1
 
@@ -326,9 +331,9 @@ All notable changes to this project will be documented in this file.
 
 ### ✨ New
 
-- support `!` negation and comma-separated `AND` terms in analyzed-files metadata search filters ([#85](https://github.com/frederikemmer/MediaLyze/issues/85))
-- add feature flags for a full-width `.media-app-shell` layout and hiding the analyzed-files quality score meter ([#91](https://github.com/frederikemmer/MediaLyze/issues/91))
-- add Excel-like drag resizing for analyzed-files table columns, with widths persisted in browser storage ([#91](https://github.com/frederikemmer/MediaLyze/issues/91))
+- support `!` negation and comma-separated `AND` terms in analyzed-files metadata search filters [#85](https://github.com/frederikemmer/MediaLyze/issues/85)
+- add feature flags for a full-width `.media-app-shell` layout and hiding the analyzed-files quality score meter [#91](https://github.com/frederikemmer/MediaLyze/issues/91)
+- add Excel-like drag resizing for analyzed-files table columns, with widths persisted in browser storage [#91](https://github.com/frederikemmer/MediaLyze/issues/91)
 
 ### 🐛 Bug fixes
 
@@ -342,7 +347,7 @@ First "rough" implementation for detecting duplicate files. May break desktop in
 
 ### ✨ New
 
-- add per-library duplicate detection with `off` (default), `filename`, `filehash`, `both` modes ([#16](https://github.com/frederikemmer/MediaLyze/issues/16))
+- add per-library duplicate detection with `off` (default), `filename`, `filehash`, `both` modes [#16](https://github.com/frederikemmer/MediaLyze/issues/16)
 - view and search through duplicates on library page
 - scan performance tuning in `App settings` with separate controls for per-scan analysis workers and parallel library scans
 
@@ -358,12 +363,12 @@ First "rough" implementation for detecting duplicate files. May break desktop in
 
 ### 🐛 Bug fixes
 - restrict `main` release publishing to real version bumps so unchanged-version commits no longer try to recreate existing tags and releases
-- allow adding new resolution categories from the settings UI without tripping the backend's immutable-id validation ([#71](https://github.com/frederikemmer/MediaLyze/issues/71))
-- fix resolution quality-boundary updates in the library quality settings when `minimum` / `ideal` values are changed ([#72](https://github.com/frederikemmer/MediaLyze/pull/72)) - by [@eivarin](https://github.com/eivarin)
+- allow adding new resolution categories from the settings UI without tripping the backend's immutable-id validation [#71](https://github.com/frederikemmer/MediaLyze/issues/71)
+- fix resolution quality-boundary updates in the library quality settings when `minimum` / `ideal` values are changed [#72](https://github.com/frederikemmer/MediaLyze/pull/72) - by [@eivarin](https://github.com/eivarin)
 - keep Windows UNC network-share paths in their normal form for `ffprobe` so desktop scans analyze files on network shares instead of only listing them
-- lower the default resolution-category minimum width and height thresholds by 5% so cropped widescreen encodes stay in their expected buckets, and document the relaxed defaults in the settings tooltip ([#79](https://github.com/frederikemmer/MediaLyze/issues/79))
-- make desktop packaging always create the bundled `backend/ffprobe` structure, auto-detect `ffprobe` on the build machine, and use more robust packaged-path fallbacks at runtime before failing ([#80](https://github.com/frederikemmer/MediaLyze/issues/80))
-- treat NAS snapshot symlink loops under `MEDIA_ROOT` as invalid paths so browse and library setup return `400` or skip the entry instead of crashing with a `500` ([#81](https://github.com/frederikemmer/MediaLyze/issues/81))
+- lower the default resolution-category minimum width and height thresholds by 5% so cropped widescreen encodes stay in their expected buckets, and document the relaxed defaults in the settings tooltip [#79](https://github.com/frederikemmer/MediaLyze/issues/79)
+- make desktop packaging always create the bundled `backend/ffprobe` structure, auto-detect `ffprobe` on the build machine, and use more robust packaged-path fallbacks at runtime before failing [#80](https://github.com/frederikemmer/MediaLyze/issues/80)
+- treat NAS snapshot symlink loops under `MEDIA_ROOT` as invalid paths so browse and library setup return `400` or skip the entry instead of crashing with a `500` [#81](https://github.com/frederikemmer/MediaLyze/issues/81)
 
 ## v0.2.5
 
@@ -373,8 +378,8 @@ First "rough" implementation for detecting duplicate files. May break desktop in
 - The browser now renders scan and library times in the user's local timezone
 
 ### 🐛 Bug fixes
-- serialize API timestamps as explicit UTC `Z` values and restore SQLite datetime fields as UTC ([#66](https://github.com/frederikemmer/MediaLyze/issues/66))
-- align clickable statistics with table - counted streams instead of files ([#67](https://github.com/frederikemmer/MediaLyze/issues/67))
+- serialize API timestamps as explicit UTC `Z` values and restore SQLite datetime fields as UTC [#66](https://github.com/frederikemmer/MediaLyze/issues/66)
+- align clickable statistics with table - counted streams instead of files [#67](https://github.com/frederikemmer/MediaLyze/issues/67)
 
 ## v0.2.4
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,3 +16,7 @@
 - Keep scope focused.
 - Describe user-visible behavior changes.
 - Do not include secrets or machine-specific artifacts.
+
+## License
+
+By contributing to MediaLyze, you agree that your contribution is submitted under the GNU Affero General Public License v3.0 (`AGPL-3.0`).

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY frontend/ ./
 RUN npm run build
 
 FROM python:3.12-alpine AS runtime
-ARG APP_VERSION=0.12.2
+ARG APP_VERSION=0.12.3
 
 LABEL name="MediaLyze"
 LABEL org.opencontainers.image.source="https://github.com/frederikemmer/MediaLyze"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY frontend/ ./
 RUN npm run build
 
 FROM python:3.12-alpine AS runtime
-ARG APP_VERSION=0.12.3
+ARG APP_VERSION=0.13.0
 
 LABEL name="MediaLyze"
 LABEL org.opencontainers.image.source="https://github.com/frederikemmer/MediaLyze"

--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,661 @@
-MIT License
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Copyright (c) 2026 Frederik Emmer
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
 
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MediaLyze
 
 <p align="center">
-  <a href="./LICENSE"><img alt="MIT License" src="https://img.shields.io/badge/License-MIT-yellow.svg"></a>
+  <a href="./LICENSE"><img alt="AGPL-3.0 License" src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg"></a>
   <img alt="Python 3.12" src="https://img.shields.io/badge/Python-3.12-3776AB?logo=python&logoColor=white">
   <img alt="FastAPI" src="https://img.shields.io/badge/FastAPI-009688?logo=fastapi&logoColor=white">
   <img alt="React 19" src="https://img.shields.io/badge/React-19-149ECA?logo=react&logoColor=white">
@@ -262,8 +262,11 @@ MediaLyze is an open-source project under active development. The current focus 
 
 [![Star History Chart](https://api.star-history.com/image?repos=frederikemmer/medialyze&type=date&legend=top-left)](https://www.star-history.com/?repos=frederikemmer%2Fmedialyze&type=date&legend=top-left)
 
-## Contributing & License
+## Contributing
 
 Contributions are welcome. Read [CONTRIBUTING.md](CONTRIBUTING.md) before opening a pull request.
 
-This project is licensed under the [MIT License](LICENSE).
+## License
+
+MediaLyze is licensed under the GNU Affero General Public License v3.0 (`AGPL-3.0`).
+See the [LICENSE](LICENSE) file for details.

--- a/ca_profile.xml
+++ b/ca_profile.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<CommunityApplications>
+  <Profile>
+    MediaLyze provides Unraid Docker templates for the self-hosted MediaLyze media analysis application. MediaLyze scans video and audio libraries with ffprobe, stores normalized technical metadata in SQLite, and exposes inspection, statistics, and scan-management workflows through a web UI.
+  </Profile>
+  <Icon>https://raw.githubusercontent.com/frederikemmer/MediaLyze/main/frontend/public/favicon-512.png</Icon>
+  <WebPage>https://github.com/frederikemmer/MediaLyze</WebPage>
+  <DonateLink>https://github.com/sponsors/frederikemmer</DonateLink>
+  <DonateText>Support MediaLyze</DonateText>
+</CommunityApplications>

--- a/ca_profile.xml
+++ b/ca_profile.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <CommunityApplications>
   <Profile>
-    MediaLyze provides Unraid Docker templates for the self-hosted MediaLyze media analysis application. MediaLyze scans video and audio libraries with ffprobe, stores normalized technical metadata in SQLite, and exposes inspection, statistics, and scan-management workflows through a web UI.
+    MediaLyze provides a self-hosted media analysis application. MediaLyze scans video and audio libraries with ffprobe, stores normalized technical metadata in SQLite, and exposes inspection, statistics, and scan-management workflows through a web UI.
   </Profile>
   <Icon>https://raw.githubusercontent.com/frederikemmer/MediaLyze/main/frontend/public/favicon-512.png</Icon>
   <WebPage>https://github.com/frederikemmer/MediaLyze</WebPage>

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medialyze-desktop",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medialyze-desktop",
-      "version": "0.12.3",
+      "version": "0.13.0",
       "license": "AGPL-3.0",
       "devDependencies": {
         "electron": "^39.8.5",

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "medialyze-desktop",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medialyze-desktop",
-      "version": "0.12.2",
+      "version": "0.12.3",
+      "license": "AGPL-3.0",
       "devDependencies": {
         "electron": "^39.8.5",
         "electron-builder": "^26.0.12",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,8 @@
 {
   "name": "medialyze-desktop",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
+  "license": "AGPL-3.0",
   "description": "Desktop packaging for the MediaLyze local media analysis app.",
   "author": "Frederik Emmer",
   "main": "main.cjs",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medialyze-desktop",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "private": true,
   "license": "AGPL-3.0",
   "description": "Desktop packaging for the MediaLyze local media analysis app.",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "medialyze-frontend",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medialyze-frontend",
-      "version": "0.12.3",
+      "version": "0.13.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@tanstack/react-virtual": "^3.13.21",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "medialyze-frontend",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "medialyze-frontend",
-      "version": "0.12.2",
+      "version": "0.12.3",
+      "license": "AGPL-3.0",
       "dependencies": {
         "@tanstack/react-virtual": "^3.13.21",
         "echarts": "^6.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,8 @@
 {
   "name": "medialyze-frontend",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "private": true,
+  "license": "AGPL-3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "medialyze-frontend",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "private": true,
   "license": "AGPL-3.0",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "medialyze"
-version = "0.12.2"
+version = "0.12.3"
 description = "Self-hosted media library analyzer for technical video metadata."
 readme = "README.md"
 requires-python = ">=3.12"
-license = { text = "MIT" }
+license = { text = "AGPL-3.0" }
 authors = [
   { name = "Frederik Emmer" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "medialyze"
-version = "0.12.3"
+version = "0.13.0"
 description = "Self-hosted media library analyzer for technical video metadata."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/unraid/templates/medialyze.xml
+++ b/unraid/templates/medialyze.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>MediaLyze</Name>
+  <Repository>ghcr.io/frederikemmer/medialyze:latest</Repository>
+  <Registry>https://ghcr.io</Registry>
+  <Network>bridge</Network>
+  <MyIP/>
+  <MyMAC/>
+  <Shell>bash</Shell>
+  <Privileged>false</Privileged>
+
+  <Support>https://github.com/frederikemmer/MediaLyze/issues</Support>
+  <Project>https://github.com/frederikemmer/MediaLyze</Project>
+  <ReadMe>https://github.com/frederikemmer/MediaLyze#readme</ReadMe>
+
+  <Overview>Self-hosted technical media analysis for large video and audio collections.</Overview>
+  <Description>
+    <![CDATA[
+    <p><strong>MediaLyze</strong> scans local media libraries with <code>ffprobe</code>, stores normalized technical metadata in SQLite, and exposes inspection, statistics, and scan-management workflows through a web UI.</p>
+    <p>MediaLyze is designed for analysis, not playback or file modification. Mount your media libraries read-only.</p>
+    <ul>
+      <li><code>/config</code>: persistent configuration and SQLite database storage.</li>
+      <li><code>/media</code>: MediaLyze media root. Mount each Unraid share as a separate folder below this path, for example <code>/media/Media</code>, <code>/media/Movies</code>, <code>/media/Shows</code>, or <code>/media/Music</code>. Do not mount one share directly to <code>/media</code> and another below it.</li>
+    </ul>
+    ]]>
+  </Description>
+
+  <Category>MediaApp:Tools MediaServer:Management Tools:Utilities</Category>
+  <WebUI>http://[IP]:[PORT:8080]/</WebUI>
+  <TemplateURL>https://raw.githubusercontent.com/frederikemmer/MediaLyze/main/unraid/templates/medialyze.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/frederikemmer/MediaLyze/main/frontend/public/favicon-512.png</Icon>
+
+  <ExtraParams/>
+  <PostArgs/>
+  <CPUset/>
+  <DateInstalled/>
+  <DonateText>Support MediaLyze</DonateText>
+  <DonateLink>https://github.com/sponsors/frederikemmer</DonateLink>
+  <Requires>Persistent storage for /config and read-only media mounts below /media.</Requires>
+
+  <Config Name="WebUI Port" Target="8080" Default="8080" Mode="tcp" Description="External port for the MediaLyze web interface." Type="Port" Display="always" Required="true" Mask="false">8080</Config>
+  <Config Name="Config" Target="/config" Default="/mnt/user/appdata/medialyze" Mode="rw" Description="Persistent configuration and SQLite database storage." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/medialyze</Config>
+  <Config Name="Primary Media Mount" Target="/media/Media" Default="/mnt/user/media" Mode="ro" Description="Required read-only media mount. Change the container path to your preferred visible name, but keep it below /media, for example /media/Movies." Type="Path" Display="always" Required="true" Mask="false">/mnt/user/media</Config>
+  <Config Name="Movies Media Mount" Target="/media/Movies" Default="" Mode="ro" Description="Optional additional read-only media mount. Change the container path to your preferred visible name, but keep it below /media, for example /media/Movies." Type="Path" Display="advanced" Required="false" Mask="false"></Config>
+  <Config Name="Shows Media Mount" Target="/media/Shows" Default="" Mode="ro" Description="Optional additional read-only media mount. Change the container path to your preferred visible name, but keep it below /media, for example /media/Shows." Type="Path" Display="advanced" Required="false" Mask="false"></Config>
+  <Config Name="Music Media Mount" Target="/media/Music" Default="" Mode="ro" Description="Optional additional read-only media mount. Change the container path to your preferred visible name, but keep it below /media, for example /media/Music." Type="Path" Display="advanced" Required="false" Mask="false"></Config>
+  <Config Name="Timezone" Target="TZ" Default="UTC" Mode="" Description="Container timezone, for example Europe/Berlin or America/New_York." Type="Variable" Display="always" Required="false" Mask="false">UTC</Config>
+  <Config Name="PUID" Target="PUID" Default="99" Mode="" Description="Optional runtime user id. On Unraid, 99 is usually nobody." Type="Variable" Display="advanced" Required="false" Mask="false">99</Config>
+  <Config Name="PGID" Target="PGID" Default="100" Mode="" Description="Optional runtime group id. On Unraid, 100 is usually users." Type="Variable" Display="advanced" Required="false" Mask="false">100</Config>
+
+  <TailscaleStateDir/>
+</Container>


### PR DESCRIPTION
## Summary

Add a Docker template for Unraid, spanish translation and change in the license to AGPL-3.0.

## Changes

- Introduced a new Docker template for MediaLyze
- Updated project version and license information
- add spanish translation

## Testing

- Verified the Docker template functionality and version updates

## Checklist

- [x] I tested the change locally.
- [x] I updated docs if behavior/config changed.
- [x] I kept the scope focused (single concern).
- [x] I did not include secrets or local machine artifacts.

