### PR TITLE
Add static ffmpeg binary support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## vUnreleased
 
+### 🐛 Bug fixes
+
+- bundle a static `ffmpeg` binary into the desktop backend so release artifacts no longer depend on the runner or target system having ffmpeg installed
+
 ## v0.13.1
 
 >2026-06-01

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -11,7 +11,24 @@
       "devDependencies": {
         "electron": "^39.8.5",
         "electron-builder": "^26.0.12",
+        "ffmpeg-static": "^5.3.0",
         "icon-gen": "^5.0.0"
+      }
+    },
+    "node_modules/@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@develar/schema-utils": {
@@ -1900,6 +1917,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2116,6 +2140,22 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "dev": true,
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -2906,6 +2946,50 @@
         }
       }
     },
+    "node_modules/ffmpeg-static": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.3.0.tgz",
+      "integrity": "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/ffmpeg-static/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ffmpeg-static/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/filelist": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
@@ -3352,6 +3436,23 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/http-response-object/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
@@ -4251,6 +4352,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg==",
+      "dev": true
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
@@ -5191,6 +5298,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "electron": "^39.8.5",
     "electron-builder": "^26.0.12",
+    "ffmpeg-static": "^5.3.0",
     "icon-gen": "^5.0.0"
   },
   "build": {

--- a/desktop/scripts/build-backend.mjs
+++ b/desktop/scripts/build-backend.mjs
@@ -6,6 +6,7 @@ import {
   rmSync,
   statSync,
 } from "node:fs";
+import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { spawnSync } from "node:child_process";
@@ -16,6 +17,7 @@ const repoRoot = path.resolve(scriptDir, "..", "..");
 const outputDir = path.join(repoRoot, "dist", "desktop-backend");
 const workDir = path.join(repoRoot, "dist", "pyinstaller-work");
 const specDir = path.join(repoRoot, "dist", "pyinstaller-spec");
+const require = createRequire(import.meta.url);
 
 export function bundledFfprobeName(platform = process.platform) {
   return platform === "win32" ? "ffprobe.exe" : "ffprobe";
@@ -80,7 +82,17 @@ export function resolveBundledFfmpegSource({
   exists = existsSync,
   stat = statSync,
   lookup = (command, args) => spawnSync(command, args, { encoding: "utf8" }),
+  staticSourceResolver = resolveStaticFfmpegSource,
 } = {}) {
+  const staticSourcePath = staticSourceResolver();
+  if (staticSourcePath) {
+    return {
+      kind: "file",
+      sourcePath: staticSourcePath,
+      executableName: bundledFfmpegName(platform),
+    };
+  }
+
   return resolveBundledToolSource({
     env,
     platform,
@@ -91,6 +103,21 @@ export function resolveBundledFfmpegSource({
     envName: "MEDIALYZE_FFMPEG_DIR",
     toolName: "ffmpeg",
   });
+}
+
+function resolveStaticFfmpegSource() {
+  try {
+    const staticBinaryPath = require("ffmpeg-static");
+    if (typeof staticBinaryPath === "string" && staticBinaryPath.trim()) {
+      return staticBinaryPath;
+    }
+  } catch (error) {
+    if (error?.code !== "MODULE_NOT_FOUND" && error?.code !== "ERR_MODULE_NOT_FOUND") {
+      throw error;
+    }
+  }
+
+  return null;
 }
 
 function resolveBundledToolSource({

--- a/desktop/scripts/build-backend.test.mjs
+++ b/desktop/scripts/build-backend.test.mjs
@@ -95,6 +95,20 @@ test("resolveBundledFfmpegSource falls back to a PATH lookup", () => {
   });
 });
 
+test("resolveBundledFfmpegSource prefers a static ffmpeg package path", () => {
+  const resolved = resolveBundledFfmpegSource({
+    env: {},
+    platform: "linux",
+    staticSourceResolver: () => "/opt/ffmpeg-static/ffmpeg",
+  });
+
+  assert.deepEqual(resolved, {
+    kind: "file",
+    sourcePath: "/opt/ffmpeg-static/ffmpeg",
+    executableName: "ffmpeg",
+  });
+});
+
 test("bundleFfprobe creates the expected ffprobe folder structure", () => {
   withTempDir((tempDir) => {
     const sourceBinary = path.join(tempDir, "ffprobe.exe");


### PR DESCRIPTION
## Summary

Bundle a static `ffmpeg` binary into the desktop backend to eliminate dependencies on the target system having `ffmpeg` installed.

## Changes

- Integrated `ffmpeg-static` package to provide a static binary

## Testing

- Added tests to ensure the static binary is resolved correctly

## Checklist

- [x] I tested the change locally.
- [x] I updated docs if behavior/config changed.
- [x] I kept the scope focused (single concern).
- [x] I did not include secrets or local machine artifacts.

