### PR TITLE
fix: include generation in Fire TV Stick 4K Max (2. Gen) profile ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## vUnreleased
 
+### 🐛 Fixed
+
+- include the second-generation suffix in the "Fire TV Stick 4K Max (2. Gen)" hardware profile ID
+
 ## v0.17.0
 
 >2026-07-27

--- a/backend/app/profile_catalog/hardware_profiles/fire-tv-stick-4k-max-2nd-gen.json
+++ b/backend/app/profile_catalog/hardware_profiles/fire-tv-stick-4k-max-2nd-gen.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "profile_version": 1,
-  "id": "fire-tv-stick-4k-max",
+  "id": "fire-tv-stick-4k-max-2nd-gen",
   "name": "Fire TV Stick 4K Max (2. Gen)",
   "category": "streaming_device",
   "manufacturer": "Amazon",

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -128,7 +128,7 @@ def test_shipped_profiles_load_with_matching_ids(tmp_path) -> None:
         "apple-tv-4k-2nd-gen",
         "apple-tv-4k-3rd-gen",
         "apple-tv-hd",
-        "fire-tv-stick-4k-max",
+        "fire-tv-stick-4k-max-2nd-gen",
         "onn-4k-2023",
     ]
     assert {profile.id for profile in list_profiles(settings, "software")} == {


### PR DESCRIPTION
## Summary

Include the generation in the Fire TV Stick 4K Max (2. Gen) hardware profile ID, consistent with the naming convention used by other profiles.

## Changes

- Rename `fire-tv-stick-4k-max.json` to `fire-tv-stick-4k-max-2nd-gen.json`
- Change the profile ID from `fire-tv-stick-4k-max` to `fire-tv-stick-4k-max-2nd-gen`
- Update the expected shipped profile ID in `test_compatibility.py`

## Compatibility

This changes an existing hardware profile ID.
Local compatibility profiles may still reference `fire-tv-stick-4k-max`. Users may need to add the hardware profile to their favorites again. In a combination profile, the hardware profile must be reselected because it is being replaced by another one.

## Testing

- `python -m pytest -v` PASSED

## Checklist

- [x] I tested the change locally.
- [x] I updated docs if behavior/config changed.
- [x] I kept the scope focused (single concern).
- [x] I did not include secrets or local machine artifacts.
